### PR TITLE
feat: ERD 기반 Entity 정의

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,11 +24,24 @@ repositories {
 }
 
 dependencies {
+	// spring boot
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// lombok annotation
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Sql logging formatter
+	// reference: https://www.baeldung.com/java-p6spy-intercept-sql-logging
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.2' //이쁘게
+
+	// logback logger
+	implementation 'ch.qos.logback:logback-classic:1.4.12'
+	implementation 'org.slf4j:slf4j-api:2.0.3'
+
+	// test environment
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/src/main/java/kernel360/techpick/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/kernel360/techpick/config/JpaAuditingConfig.java
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfiig {}
+public class JpaAuditingConfig {}

--- a/backend/src/main/java/kernel360/techpick/config/JpaAuditingConfiig.java
+++ b/backend/src/main/java/kernel360/techpick/config/JpaAuditingConfiig.java
@@ -1,0 +1,8 @@
+package kernel360.techpick.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiig {}

--- a/backend/src/main/java/kernel360/techpick/config/P6SpySqlLoggerConfig.java
+++ b/backend/src/main/java/kernel360/techpick/config/P6SpySqlLoggerConfig.java
@@ -1,0 +1,63 @@
+package kernel360.techpick.config;
+
+import java.sql.SQLException;
+import java.util.Locale;
+import static org.springframework.util.StringUtils.hasText;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+/**
+ * Jdbc가 DB Connection을 얻은 이후에 로깅 포맷을 P6SpyOptions가 가로채도록 하는 Bean입니다.
+ */
+@Profile({"default", "local", "dev"}) // WARN: Do not use in production mode.
+@Component
+public class P6SpySqlLoggerConfig extends JdbcEventListener implements MessageFormattingStrategy {
+
+	@Override
+	public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+		P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+	}
+
+	@Override
+	public String formatMessage(int connectionId, String now, long elapsed, String category,
+		String prepared, String sql, String url) {
+		return highlight(format(category, sql));
+	}
+
+	private String highlight(String sql) {
+		return FormatStyle.HIGHLIGHT.getFormatter().format(sql);
+	}
+
+	private String format(String category, String sql) {
+		if (hasText(sql) && isStatement(category)) {
+			if (isDdl(trim(sql))) {
+				return FormatStyle.DDL.getFormatter().format(sql);
+			}
+			return FormatStyle.BASIC.getFormatter().format(sql);
+		}
+		return sql;
+	}
+
+	private static boolean isDdl(String trimmedSql) {
+		return trimmedSql.startsWith("create")
+			|| trimmedSql.startsWith("alter")
+			|| trimmedSql.startsWith("drop")
+			|| trimmedSql.startsWith("comment");
+	}
+
+	private static String trim(String sql) {
+		return sql.trim().toLowerCase(Locale.ROOT);
+	}
+
+	private static boolean isStatement(String category) {
+		return Category.STATEMENT.getName().equals(category);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/entity/admin/Administrator.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/Administrator.java
@@ -1,0 +1,35 @@
+package kernel360.techpick.entity.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "administrator")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Administrator {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "administrator_id", updatable = false)
+	private Long administratorId;
+
+	// 관리자 로그인 이메일
+	@Column(name = "email", nullable = false, unique = true)
+	private String email;
+
+	// 비밀번호
+	@Column(name = "password", nullable = false)
+	private String password;
+
+	// 관리자 이름
+	@Column(name = "name", nullable = false)
+	private String name;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/admin/Administrator.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/Administrator.java
@@ -7,18 +7,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(name = "administrator")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Administrator {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "administrator_id", updatable = false)
+	@Column(name = "administrator_id")
 	private Long administratorId;
 
 	// 관리자 로그인 이메일

--- a/backend/src/main/java/kernel360/techpick/entity/admin/CrawlingTopicMapping.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/CrawlingTopicMapping.java
@@ -1,0 +1,36 @@
+package kernel360.techpick.entity.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * NOTE: 이 부분은 좀 더 토의가 필요 합니다.
+ *
+ */
+@Table(name = "crawling_topic_mapping")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrawlingTopicMapping {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "crawling_topic_mapping_id", updatable = false)
+	private Long crawlingTopicMappingId;
+
+	// TODO: 태그 종류는 블로그별로 다 달라질 것이다.
+	//       아래 처럼 하면, 블로그가 추가될 때마다 우리가 직접 매핑해줘야 한다.
+
+	// TODO: 아래와 같이 하면, 블로그별 태그 mapper를 구현할 필요 없음.
+	//       아래 mappingString이 공용이기 때문.
+	//       ex. "#Spring#스프링#spring" --> 모든 블로그에 적용
+	@Column(name = "mapping_string", nullable = false)
+	private String mappingString;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/admin/CrawlingTopicMapping.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/CrawlingTopicMapping.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,12 +18,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "crawling_topic_mapping")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CrawlingTopicMapping {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "crawling_topic_mapping_id", updatable = false)
+	@Column(name = "crawling_topic_mapping_id")
 	private Long crawlingTopicMappingId;
 
 	// TODO: 태그 종류는 블로그별로 다 달라질 것이다.

--- a/backend/src/main/java/kernel360/techpick/entity/admin/Topic.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/Topic.java
@@ -1,0 +1,30 @@
+package kernel360.techpick.entity.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// NOTE: 관리자만 수정 가능한 테이블 입니다.
+// TODO: 기본 값은 "분류 없음" 레코드 입니다.
+//       '분류 없음'을 테이블에 반드시 존재하도록 설정해야 합니다.
+@Table(name = "topic")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Topic {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "topic_id", updatable = false)
+	private Long topicId;
+
+	// 주제명 (중복된 주제 명은 없어야 합니다.)
+	@Column(name = "topic_name", nullable = false, unique = true)
+	private String topicName;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/admin/Topic.java
+++ b/backend/src/main/java/kernel360/techpick/entity/admin/Topic.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,12 +17,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "topic")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Topic {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "topic_id", updatable = false)
+	@Column(name = "topic_id")
 	private Long topicId;
 
 	// 주제명 (중복된 주제 명은 없어야 합니다.)

--- a/backend/src/main/java/kernel360/techpick/entity/article/Article.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/Article.java
@@ -10,27 +10,26 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kernel360.techpick.entity.blog.Blog;
 import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
-import kernel360.techpick.entity.admin.Topic;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(name = "article")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends CreatedAndUpdatedTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "article_id", updatable = false)
+	@Column(name = "article_id")
 	private Long articleId;
 
 	// 원문 제목
@@ -46,8 +45,8 @@ public class Article extends CreatedAndUpdatedTimeColumn {
 	private LocalDateTime publishedAt;
 
 	// 원문 작성자
-	@Column(name = "author", nullable = false)
-	private LocalDateTime author;
+	@Column(name = "author") // nullable (수집 안될 수도 있음)
+	private String author;
 
 	// 원문 출처 블로그
 	@ManyToOne
@@ -58,17 +57,20 @@ public class Article extends CreatedAndUpdatedTimeColumn {
 	@Column(name = "crawled_at", nullable = false)
 	private LocalDateTime crawled_at;
 
-	// 게시글 상세 id - FK
-	@OneToOne
-	@JoinColumn(name = "article_detail_id", nullable = false, unique = true)
-	private ArticleDetail articleDetail;
+	// 대표 이미지 CDN url
+	@Column(name = "image_url")
+	private String imageUrl; // nullable
+
+	// [사용자 - 관심 토픽] 1:N 테이블
+	@OneToMany(mappedBy = "article")
+	private List<ArticleTopic> articleTopics = new ArrayList<>();
 
 	// 게시글-토픽 관계 테이블
-	@ManyToMany
-	@JoinTable(
-		name = "article_topic",
-		joinColumns = @JoinColumn(name = "article_id", nullable = false),
-		inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
-	)
-	private List<Topic> topics = new ArrayList<>();
+	// @ManyToMany
+	// @JoinTable(
+	// 	name = "article_topic",
+	// 	joinColumns = @JoinColumn(name = "article_id", nullable = false),
+	// 	inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
+	// )
+	// private List<Topic> topics = new ArrayList<>();
 }

--- a/backend/src/main/java/kernel360/techpick/entity/article/Article.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/Article.java
@@ -1,0 +1,74 @@
+package kernel360.techpick.entity.article;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import kernel360.techpick.entity.blog.Blog;
+import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
+import kernel360.techpick.entity.admin.Topic;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "article")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends CreatedAndUpdatedTimeColumn {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "article_id", updatable = false)
+	private Long articleId;
+
+	// 원문 제목
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	// 원문 링크
+	@Column(name = "url", nullable = false)
+	private String url;
+
+	// 원문 작성 일자
+	@Column(name = "published_at", nullable = false)
+	private LocalDateTime publishedAt;
+
+	// 원문 작성자
+	@Column(name = "author", nullable = false)
+	private LocalDateTime author;
+
+	// 원문 출처 블로그
+	@ManyToOne
+	@JoinColumn(name = "blog_id", nullable = false)
+	private Blog blog;
+
+	// 수집 날짜 (크롤링 시각)
+	@Column(name = "crawled_at", nullable = false)
+	private LocalDateTime crawled_at;
+
+	// 게시글 상세 id - FK
+	@OneToOne
+	@JoinColumn(name = "article_detail_id", nullable = false, unique = true)
+	private ArticleDetail articleDetail;
+
+	// 게시글-토픽 관계 테이블
+	@ManyToMany
+	@JoinTable(
+		name = "article_topic",
+		joinColumns = @JoinColumn(name = "article_id", nullable = false),
+		inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
+	)
+	private List<Topic> topics = new ArrayList<>();
+}

--- a/backend/src/main/java/kernel360/techpick/entity/article/ArticleDetail.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/ArticleDetail.java
@@ -1,0 +1,27 @@
+package kernel360.techpick.entity.article;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "article_detail")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleDetail {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "article_detail_id", updatable = false)
+	private Long articleDetailId;
+
+	// 대표 이미지 CDN url
+	@Column(name = "image_url")
+	private String imageUrl; // nullable
+}

--- a/backend/src/main/java/kernel360/techpick/entity/article/ArticleTopic.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/ArticleTopic.java
@@ -5,23 +5,32 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kernel360.techpick.entity.admin.Topic;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "article_detail")
+@Table(name = "article_topic")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ArticleDetail {
+public class ArticleTopic {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "article_detail_id", updatable = false)
-	private Long articleDetailId;
+	@Column(name = "article_topic_id")
+	private Long articleTopicId;
 
-	// 대표 이미지 CDN url
-	@Column(name = "image_url")
-	private String imageUrl; // nullable
+	@ManyToOne
+	@JoinColumn(name = "article_id")
+	private Article article;
+
+	@ManyToOne
+	@JoinColumn(name = "topic_id")
+	private Topic topic;
 }

--- a/backend/src/main/java/kernel360/techpick/entity/article/RawCrawledArticle.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/RawCrawledArticle.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,12 +19,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "raw_crawled_article")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RawCrawledArticle extends CreatedAndUpdatedTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "raw_crawled_article_id", updatable = false)
+	@Column(name = "raw_crawled_article_id")
 	private Long rawCrawledArticleId;
 
 	// TODO: 아래 크롤링 데이터 칼럼은 토의 후 바뀔 예정 입니다.

--- a/backend/src/main/java/kernel360/techpick/entity/article/RawCrawledArticle.java
+++ b/backend/src/main/java/kernel360/techpick/entity/article/RawCrawledArticle.java
@@ -1,0 +1,33 @@
+package kernel360.techpick.entity.article;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * NOTE: 크롤링한 Raw 데이터를 삽입하는 테이블입니다.
+ *       데이터 형식은 바뀔 수 있습니다.
+ */
+@Table(name = "raw_crawled_article")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RawCrawledArticle extends CreatedAndUpdatedTimeColumn {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "raw_crawled_article_id", updatable = false)
+	private Long rawCrawledArticleId;
+
+	// TODO: 아래 크롤링 데이터 칼럼은 토의 후 바뀔 예정 입니다.
+	// 크롤링 데이터
+	@Column(name = "data", nullable = false)
+	private String data;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/blog/Blog.java
+++ b/backend/src/main/java/kernel360/techpick/entity/blog/Blog.java
@@ -1,0 +1,42 @@
+package kernel360.techpick.entity.blog;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+// NOTE: 관리자만 수정 가능한 테이블 입니다.
+// TODO: rss를 지원하지 않는 경우 어떻게 처리할지 고민 필요.
+@Table(name = "blog")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Blog {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "blog_id", updatable = false)
+	private Long blogId;
+
+	// 블로그명
+	@Column(name = "blog_name", nullable = false)
+	private String blogName;
+
+	// 블로그 주소
+	@Column(name = "blog_url", nullable = false)
+	private String blogUrl;
+
+	// RSS service url
+	@Column(name = "rss_url")
+	private String rssUrl; // nullable
+
+	// 블로그 기본 대표 이미지
+	@Column(name = "default_image", nullable = false)
+	private String base64Image;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/blog/Blog.java
+++ b/backend/src/main/java/kernel360/techpick/entity/blog/Blog.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,12 +17,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "blog")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Blog {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "blog_id", updatable = false)
+	@Column(name = "blog_id")
 	private Long blogId;
 
 	// 블로그명

--- a/backend/src/main/java/kernel360/techpick/entity/common/CreatedAndUpdatedTimeColumn.java
+++ b/backend/src/main/java/kernel360/techpick/entity/common/CreatedAndUpdatedTimeColumn.java
@@ -1,0 +1,28 @@
+package kernel360.techpick.entity.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CreatedAndUpdatedTimeColumn {
+
+	// 생성 시간 자동 부여
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	protected LocalDateTime createdAt;
+
+	// 수정 시간 자동 부여
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	protected LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/event/AricleViewEvent.java
+++ b/backend/src/main/java/kernel360/techpick/entity/event/AricleViewEvent.java
@@ -1,0 +1,45 @@
+package kernel360.techpick.entity.event;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kernel360.techpick.entity.article.Article;
+import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// NOTE: 사용자 조회 추적 모델
+// TODO: 1분 동안 반복 되는 조회는 1번으로 칠 것.
+@Table(name = "article_view_event")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AricleViewEvent extends CreatedAndUpdatedTimeColumn {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "article_view_event_id", updatable = false)
+	private Long articleViewEventId;
+
+	// 이메일
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	// 이벤트 발생 위치
+	@Enumerated(EnumType.STRING)
+	@Column(name = "event_location", nullable = false)
+	private EventLocation eventLocation;
+
+	// 조회한 게시글
+	@ManyToOne
+	@JoinColumn(name = "article_id", nullable = false)
+	private Article article;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/event/AricleViewEvent.java
+++ b/backend/src/main/java/kernel360/techpick/entity/event/AricleViewEvent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,7 @@ import jakarta.persistence.Table;
 import kernel360.techpick.entity.article.Article;
 import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,12 +23,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "article_view_event")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AricleViewEvent extends CreatedAndUpdatedTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "article_view_event_id", updatable = false)
+	@Column(name = "article_view_event_id")
 	private Long articleViewEventId;
 
 	// 이메일
@@ -39,7 +42,7 @@ public class AricleViewEvent extends CreatedAndUpdatedTimeColumn {
 	private EventLocation eventLocation;
 
 	// 조회한 게시글
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY) // article 은 즉시 조회될 필요 없음
 	@JoinColumn(name = "article_id", nullable = false)
 	private Article article;
 }

--- a/backend/src/main/java/kernel360/techpick/entity/event/EventLocation.java
+++ b/backend/src/main/java/kernel360/techpick/entity/event/EventLocation.java
@@ -1,0 +1,11 @@
+package kernel360.techpick.entity.event;
+
+// TODO: 아래는 일단 초안. 정확한 분류는 토의 후에 결정할 것.
+// 이벤트 발생 위치 Enum.
+// ArticleViewEvent 에서 사용.
+public enum EventLocation {
+	SUBSCRIPTION_EMAIL,
+	SITE_HOME,
+	SITE_MY_PAGE,
+	// 추가 예정
+}

--- a/backend/src/main/java/kernel360/techpick/entity/subscriber/EmailSubscriber.java
+++ b/backend/src/main/java/kernel360/techpick/entity/subscriber/EmailSubscriber.java
@@ -1,0 +1,28 @@
+package kernel360.techpick.entity.subscriber;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "email_subscriber")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailSubscriber extends CreatedAndUpdatedTimeColumn {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "email_subscriber_id", updatable = false)
+	private Long emailSubscriberId;
+
+	// 구독자 이메일
+	@Column(name = "email", nullable = false)
+	private String email;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/subscriber/EmailSubscriber.java
+++ b/backend/src/main/java/kernel360/techpick/entity/subscriber/EmailSubscriber.java
@@ -8,18 +8,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import kernel360.techpick.entity.common.CreatedAndUpdatedTimeColumn;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Table(name = "email_subscriber")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailSubscriber extends CreatedAndUpdatedTimeColumn {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "email_subscriber_id", updatable = false)
+	@Column(name = "email_subscriber_id")
 	private Long emailSubscriberId;
 
 	// 구독자 이메일

--- a/backend/src/main/java/kernel360/techpick/entity/user/AgeGroup.java
+++ b/backend/src/main/java/kernel360/techpick/entity/user/AgeGroup.java
@@ -1,0 +1,10 @@
+package kernel360.techpick.entity.user;
+
+// TODO: 아래는 일단 초안. 정확한 분류는 토의 후에 결정할 것.
+public enum AgeGroup {
+	G10, // 10대
+	G20, // 20대
+	G30, // 30대
+	G40, // 40대
+	G50, // 50대
+}

--- a/backend/src/main/java/kernel360/techpick/entity/user/JobGroup.java
+++ b/backend/src/main/java/kernel360/techpick/entity/user/JobGroup.java
@@ -1,0 +1,26 @@
+package kernel360.techpick.entity.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// NOTE: 관리자만 수정 가능한 테이블 입니다.
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobGroup {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "jobgroup_id", updatable = false)
+	private Long jobGroupId;
+
+	// 직군 명
+	@Column(name = "jobgroup_name", nullable = false)
+	private String jobGroupName;
+}

--- a/backend/src/main/java/kernel360/techpick/entity/user/User.java
+++ b/backend/src/main/java/kernel360/techpick/entity/user/User.java
@@ -11,16 +11,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import kernel360.techpick.entity.admin.Topic;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,12 +29,13 @@ import lombok.NoArgsConstructor;
 @SQLRestriction("removed_at IS NULL")
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "user_id", updatable = false)
+	@Column(name = "user_id")
 	private Long userId;
 
 	// 소셜 로그인 이메일
@@ -47,20 +48,24 @@ public class User {
 	private AgeGroup ageGroup;
 
 	// 직군 분류
-	@ManyToOne
-	@JoinColumn(name = "jobgroup_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "job_group_id", nullable = false)
 	private JobGroup jobGroup;
 
 	// Soft Delete - 삭제 시간
 	@Column(name = "removed_at")
 	private LocalDateTime removedAt; // nullable
 
+	// [사용자 - 관심 토픽] 1:N 테이블
+	@OneToMany(mappedBy = "user")
+	private List<UserTopic> userTopics = new ArrayList<>();
+
 	// [사용자 - 관심 토픽] 관계 테이블
-	@ManyToMany
-	@JoinTable(
-		name = "user_topic",
-		joinColumns = @JoinColumn(name = "user_id", nullable = false),
-		inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
-	)
-	private List<Topic> topics = new ArrayList<>();
+	// @ManyToMany
+	// @JoinTable(
+	// 	name = "user_topic",
+	// 	joinColumns = @JoinColumn(name = "user_id", nullable = false),
+	// 	inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
+	// )
+	// private List<Topic> topics = new ArrayList<>();
 }

--- a/backend/src/main/java/kernel360/techpick/entity/user/User.java
+++ b/backend/src/main/java/kernel360/techpick/entity/user/User.java
@@ -1,0 +1,66 @@
+package kernel360.techpick.entity.user;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kernel360.techpick.entity.admin.Topic;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "user")
+@SQLDelete(sql = "UPDATE user SET removed_at = CURRENT_TIMESTAMP WHERE user_id=?")
+@SQLRestriction("removed_at IS NULL")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id", updatable = false)
+	private Long userId;
+
+	// 소셜 로그인 이메일
+	@Column(name = "email", nullable = false, unique = true)
+	private String email;
+
+	// 연령층 분류
+	@Column(name = "age_group", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private AgeGroup ageGroup;
+
+	// 직군 분류
+	@ManyToOne
+	@JoinColumn(name = "jobgroup_id", nullable = false)
+	private JobGroup jobGroup;
+
+	// Soft Delete - 삭제 시간
+	@Column(name = "removed_at")
+	private LocalDateTime removedAt; // nullable
+
+	// [사용자 - 관심 토픽] 관계 테이블
+	@ManyToMany
+	@JoinTable(
+		name = "user_topic",
+		joinColumns = @JoinColumn(name = "user_id", nullable = false),
+		inverseJoinColumns = @JoinColumn(name = "topic_id", nullable = false)
+	)
+	private List<Topic> topics = new ArrayList<>();
+}

--- a/backend/src/main/java/kernel360/techpick/entity/user/UserTopic.java
+++ b/backend/src/main/java/kernel360/techpick/entity/user/UserTopic.java
@@ -5,26 +5,32 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kernel360.techpick.entity.admin.Topic;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// NOTE: 관리자만 수정 가능한 테이블 입니다.
-@Table(name = "job_group")
+@Table(name = "user_topic")
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class JobGroup {
+public class UserTopic {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "job_group_id")
-	private Long jobGroupId;
+	@Column(name = "user_topic_id")
+	private Long userTopicInterestId;
 
-	// 직군 명
-	@Column(name = "job_group_name", nullable = false)
-	private String jobGroupName;
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne
+	@JoinColumn(name = "topic_id")
+	private Topic topic;
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -11,11 +11,10 @@ spring:
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect # MySQL 버전에 맞게 설정하세요
-        format_sql: true
+        format_sql: false
+        show_sql: false
     hibernate:
       ddl-auto: update # 이 부분 설정 주의 필요
-    show-sql: true
   datasource:
     url: ${DOCKER_MYSQL_URL}
     username: ${DOCKER_MYSQL_USERNAME}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <!-- ``````````````````````` CONVERSION RULE SETTING ```````````````````````````` -->
+
+    <!-- 콘솔 출력 색상 적용 (참고: https://oingdaddy.tistory.com/257)   -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+    <!-- ``````````````````````` PROPERTY VARIABLE SETTING ```````````````````````````` -->
+
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){green} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="CONSOLE_LOG_CHARSET" value="${CONSOLE_LOG_CHARSET:-default}"/>
+
+    <!-- 로그 경로 (Logback 은 환경 번수 적용 불가) -->
+    <property name="LOG_PATH" value="data/logs" />
+    <property name="DATE_DIR" value="%d{yyyy-MM-dd}" />
+
+    <!-- ``````````````````````` APPENDER SETTING ```````````````````````````` -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>${CONSOLE_LOG_CHARSET}</charset>
+        </encoder>
+    </appender>
+
+    <!-- logback에 Spring Boot 기본 로그 출력 스타일 적용 -->
+    <appender name="FILE-ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 로그 파일을 일자, 크기 별로 생성 설정 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- each archived file, size max 10MB -->
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <fileNamePattern>${LOG_PATH}/${DATE_DIR}/application.%i.log</fileNamePattern>
+            <!-- total size of all archive files, if total size > 20GB, it will delete old archived file -->
+            <totalSizeCap>20GB</totalSizeCap>
+            <!-- 60 days to keep -->
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+        <!-- 로그를 남길 패턴 설정 -->
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35}[%line] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ``````````````````````` LOGGER SETTING ```````````````````````````` -->
+    <!-- "additivity=false"를 하면 해당 <logger>에서만 로깅 되고, 다른 곳으로 전달 되지 않는다.
+        (ref: https://mkyong.com/logging/logback-duplicate-log-messages/) -->
+
+    <!-- (1) 프로젝트 전체 로그 설정  -->
+    <logger name="kernel360.techpick" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE-ROLLING"/>
+    </logger>
+
+    <!-- (2) SQL문 출력은 p6spy를 통해 콘솔 로만 출력 합니다. (파일 저장 X)  -->
+    <logger name="p6spy" level="info" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- (3) root info 레벨은 파일과 콘솔에 모두 출력 합니다. -->
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE-ROLLING"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
- Close #14 

## What is this PR? 🔍

- 기능 : ERD 기반 Entity 정의
- issue : #14 

## Changes 📝
- ERD 기반 엔티티 13개 추가
   - [`crawling_topic_mapping`](https://github.com/Kernel360/F2-TECHPICK/blob/back/feat/%2314/backend/src/main/java/kernel360/techpick/entity/admin/CrawlingTopicMapping.java): 블로그 태그 - 토픽 매핑 설정 테이블 :warning: 주석 확인해주세요.
   - [`raw_crawled_article`](https://github.com/Kernel360/F2-TECHPICK/blob/back/feat/%2314/backend/src/main/java/kernel360/techpick/entity/article/RawCrawledArticle.java) : 크롤링데이터를 밀어넣는 Raw 테이블. :warning: 칼럼 타입은 변경 예정입니다.
   - 참고
[ER 다이어그램 링크](https://www.drawdb.app/editor?shareId=f1baf5f261e24916090637074dd899b0)

- SQL 로깅 + logback 설정
  - logback : File Appender가 `/data` 경로에 로그 파일을 생성함.
  - p6spy : SQL 개행 및 값 표시
## Precaution
- 테이블 제약조건 중 `not null`을 최대한 설정했음. 
- 추후 불필요한 제약조건은 빼거나 추가 예정.



