### PR TITLE
feat: mysql에서 rss blog url sql 파일 import

### DIFF
--- a/backend/data/develop/mysql-files/data.sql
+++ b/backend/data/develop/mysql-files/data.sql
@@ -1,0 +1,9 @@
+-- BULK INSERT (STATIC DATA)
+
+LOAD DATA INFILE '/var/lib/mysql-files/develop/rss_blog.csv'
+    INTO TABLE rss_blog
+    FIELDS TERMINATED BY ','
+    LINES TERMINATED BY '\n'
+    IGNORE 1 LINES
+    (@source_name, @url)
+    SET rss_feed_url = @url, created_at = now(), updated_at = now();

--- a/backend/data/develop/mysql-files/rss_blog.csv
+++ b/backend/data/develop/mysql-files/rss_blog.csv
@@ -20,7 +20,6 @@ CJ OnStyle,https://medium.com/feed/cj-onstyle
 브랜디,https://labs.brandi.co.kr/feed
 넷마블,https://netmarble.engineering/rss
 11번가,https://11st-tech.github.io/rss/
-Gmarket,https://dev.gmarket.com/rss
 원티드,https://medium.com/feed/wantedjobs
 인프랩,https://tech.inflab.com/rss.xml
 티빙,https://medium.com/feed/tving-team

--- a/backend/project-setup/rss_setting.md
+++ b/backend/project-setup/rss_setting.md
@@ -1,0 +1,11 @@
+### docker mysql 접속
+
+1. docker exec -it techpick-mysql sh
+2. mysql -u root -p
+3. show databases;
+4. use techpick_db;
+5. show tables;
+
+### mysql에서 data.sql 파일 실행 및 rss csv 파일 insert
+
+6. source /var/lib/mysql-files/develop/data.sql;

--- a/backend/src/main/java/kernel360/techpick/core/model/rss/RssSupportingBlog.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/rss/RssSupportingBlog.java
@@ -23,7 +23,7 @@ public class RssSupportingBlog extends TimeTracking {
 	private Long id;
 
 	// Rss 피드 주소
-	@Column(name = "rss_feed_url", nullable = false)
+	@Column(name = "rss_feed_url", nullable = false, unique = true)
 	private String rssFeedUrl;
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,9 +1,0 @@
--- BULK INSERT (STATIC DATA)
-
-LOAD DATA INFILE '/var/lib/mysql-files/develop/rss_blog.csv'
-    INTO TABLE rss_blog
-    FIELDS TERMINATED BY ','
-    LINES TERMINATED BY '\n'
-    IGNORE 1 LINES
-    (@source_name, @url)
-    SET rss_feed_url = @url, created_at = now(), updated_at = now();


### PR DESCRIPTION
- Close #95 

## What is this PR? 🔍

- 기능 : mysql에서 rss blog url sql + csv 파일 import
- issue : #95 

## Changes 📝
docker mysql에 접속해서 sql 파일 import 하는 방법 정의
data.sql 파일 안에 csv 파일 load 하는 명령어 정의 되어 있음.
data.sql 파일 import 시 rss csv 파일 로드됨.

`rss_blog.csv` 중복된 url 제거
`RssSupportingBlog` rssFeedUrl unique index 추가

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution
- 배포 서버에 1번만 csv 파일 load
- 관리자가 크롤링할 링크 추가
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
