### PR TITLE
[feat] Folder Service 구현

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -54,6 +54,10 @@ public class Folder extends TimeTracking {
 		this.parent = parent;
 	}
 
+	public void updateParent(Folder parent) {
+		this.parent = parent;
+	}
+
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
 	public static Folder create(String name, Folder parent, FolderType folderType, User user) {
 		return new Folder(name, parent, folderType, user);

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -42,14 +42,15 @@ public class Folder extends TimeTracking {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	private Folder(String name, Folder parent, FolderType folderType) {
+	private Folder(String name, Folder parent, FolderType folderType, User user) {
 		this.name = name;
 		this.parent = parent;
 		this.folderType = folderType;
+		this.user = user;
 	}
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
-	public static Folder create(String name, Folder parent, FolderType folderType) {
-		return new Folder(name, parent, folderType);
+	public static Folder create(String name, Folder parent, FolderType folderType, User user) {
+		return new Folder(name, parent, folderType, user);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -49,6 +49,11 @@ public class Folder extends TimeTracking {
 		this.user = user;
 	}
 
+	public void update(String name, Folder parent) {
+		this.name = name;
+		this.parent = parent;
+	}
+
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
 	public static Folder create(String name, Folder parent, FolderType folderType, User user) {
 		return new Folder(name, parent, folderType, user);

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
@@ -1,0 +1,33 @@
+package kernel360.techpick.feature.folder.model;
+
+import org.springframework.stereotype.Component;
+
+import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.core.model.folder.FolderType;
+import kernel360.techpick.core.model.user.User;
+import kernel360.techpick.feature.folder.service.dto.FolderCreateRequest;
+import kernel360.techpick.feature.folder.service.dto.FolderResponse;
+import kernel360.techpick.feature.user.UserRepository;
+import kernel360.techpick.feature.user.exception.ApiUserException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FolderMapper {
+
+	private final UserRepository userRepository;
+
+	public Folder createFolder(Long userId, FolderCreateRequest request, Folder parent) throws ApiUserException {
+		User user = userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
+		return Folder.create(request.name(), parent, FolderType.GENERAL, user);
+	}
+
+	public FolderResponse createResponse(Folder folder) {
+		return new FolderResponse(
+			folder.getId(),
+			folder.getName(),
+			folder.getParent().getId(),
+			folder.getUser().getId()
+		);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
@@ -1,0 +1,41 @@
+package kernel360.techpick.feature.folder.model;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.feature.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.folder.repository.FolderRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FolderProvider {
+
+	private final FolderRepository folderRepository;
+
+	public Folder save(Folder folder) {
+		return folderRepository.save(folder);
+	}
+
+	public Folder findById(Long folderId) {
+		return folderRepository.findById(folderId).orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+	}
+
+	public List<Folder> findAllByUserId(Long userId) {
+		return folderRepository.findAllByUserId(userId);
+	}
+
+	public List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId) {
+		return folderRepository.findAllByUserIdAndParentId(userId, parentId);
+	}
+
+	public void deleteById(Long folderId) {
+		folderRepository.deleteById(folderId);
+	}
+
+	public boolean existsByUserIdAndName(Long userId, String name) {
+		return folderRepository.existsByUserIdAndName(userId, name);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.folder.repository.FolderRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,14 @@ public class FolderProvider {
 
 	public List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId) {
 		return folderRepository.findAllByUserIdAndParentId(userId, parentId);
+	}
+
+	public Folder findUnclassified(Long userId) {
+		return folderRepository.findByUserIdAndFolderType(userId, FolderType.UNCLASSIFIED);
+	}
+
+	public Folder findRecycleBin(Long userId) {
+		return folderRepository.findByUserIdAndFolderType(userId, FolderType.RECYCLE_BIN);
 	}
 
 	public void deleteById(Long folderId) {

--- a/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.core.model.folder.FolderType;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
@@ -13,6 +14,8 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	List<Folder> findAllByUserId(Long userId);
 
 	List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId);
+
+	Folder findByUserIdAndFolderType(Long userId, FolderType folderType);
 
 	boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
@@ -1,0 +1,18 @@
+package kernel360.techpick.feature.folder.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kernel360.techpick.core.model.folder.Folder;
+
+@Repository
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+	List<Folder> findAllByUserId(Long userId);
+
+	List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId);
+
+	boolean existsByUserIdAndName(Long userId, String name);
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.jsonwebtoken.lang.Assert;
+import jakarta.validation.constraints.NotNull;
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.folder.model.FolderMapper;
@@ -107,12 +107,9 @@ public class FolderService {
 		folderProvider.deleteById(folderId);
 	}
 
-	private void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
+	private void validateFolderAccess(Long userId, @NotNull Folder folder) throws ApiFolderException {
 
-		// FolderProvider에서만 Folder 엔티티를 얻을 수 있는데, FolderProvider는 null을 반환하지 않음
-		// Folder가 null이라는 것은 개발자가 잘못된 값을 넣었다는 것
-		Assert.notNull(folder, "검증하려는 폴더는 null일 수 없음");
-		if (Objects.equals(userId, folder.getUser().getId())) {
+		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -39,7 +39,7 @@ public class FolderService {
 
 	@Transactional(readOnly = true)
 	public List<FolderResponse> getFolderListByUserId(Long userId) {
-		
+
 		return folderProvider.findAllByUserId(userId)
 			.stream()
 			.map(folderMapper::createResponse)
@@ -70,6 +70,28 @@ public class FolderService {
 		validateDuplicateFolderName(userId, request.name());
 
 		targetFolder.update(request.name(), parent);
+		folderProvider.save(targetFolder);
+	}
+
+	@Transactional
+	public void moveToUnclassified(Long userId, Long folderId) {
+
+		// 이동하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(folderId);
+		validateFolderAccess(userId, targetFolder);
+
+		targetFolder.updateParent(folderProvider.findUnclassified(userId));
+		folderProvider.save(targetFolder);
+	}
+
+	@Transactional
+	public void moveToRecycleBin(Long userId, Long folderId) {
+
+		// 이동하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(folderId);
+		validateFolderAccess(userId, targetFolder);
+
+		targetFolder.updateParent(folderProvider.findRecycleBin(userId));
 		folderProvider.save(targetFolder);
 	}
 

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.jsonwebtoken.lang.Assert;
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.folder.model.FolderMapper;
@@ -108,7 +109,10 @@ public class FolderService {
 
 	private void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
 
-		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
+		// FolderProvider에서만 Folder 엔티티를 얻을 수 있는데, FolderProvider는 null을 반환하지 않음
+		// Folder가 null이라는 것은 개발자가 잘못된 값을 넣었다는 것
+		Assert.notNull(folder, "검증하려는 폴더는 null일 수 없음");
+		if (Objects.equals(userId, folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -1,0 +1,100 @@
+package kernel360.techpick.feature.folder.service;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.feature.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.folder.model.FolderMapper;
+import kernel360.techpick.feature.folder.model.FolderProvider;
+import kernel360.techpick.feature.folder.service.dto.FolderCreateRequest;
+import kernel360.techpick.feature.folder.service.dto.FolderResponse;
+import kernel360.techpick.feature.folder.service.dto.FolderUpdateRequest;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FolderService {
+
+	private final FolderProvider folderProvider;
+	private final FolderMapper folderMapper;
+
+	@Transactional
+	public FolderResponse createFolder(Long userId, FolderCreateRequest request) throws ApiFolderException {
+
+		// 생성하려는 폴더의 부모가 본인 폴더인지 검증
+		Folder parent = folderProvider.findById(request.parentId());
+		validateFolderAccess(userId, parent);
+
+		// 생성하려는 폴더 이름이 중복되는지 검증
+		validateDuplicateFolderName(userId, request.name());
+
+		Folder folder = folderProvider.save(folderMapper.createFolder(userId, request, parent));
+
+		return folderMapper.createResponse(folder);
+	}
+
+	@Transactional(readOnly = true)
+	public List<FolderResponse> getFolderListByUserId(Long userId) {
+		
+		return folderProvider.findAllByUserId(userId)
+			.stream()
+			.map(folderMapper::createResponse)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<FolderResponse> getFolderListByParentId(Long userId, Long parentId) {
+
+		return folderProvider.findAllByUserIdAndParentId(userId, parentId)
+			.stream()
+			.map(folderMapper::createResponse)
+			.toList();
+	}
+
+	@Transactional
+	public void updateFolder(Long userId, FolderUpdateRequest request) throws ApiFolderException {
+
+		// 변경하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(request.id());
+		validateFolderAccess(userId, targetFolder);
+
+		// 변경하려는 폴더의 부모가 본인 폴더인지 검증
+		Folder parent = folderProvider.findById(request.parentId());
+		validateFolderAccess(userId, parent);
+
+		// 수정하려는 폴더 이름이 중복되는지 검증
+		validateDuplicateFolderName(userId, request.name());
+
+		targetFolder.update(request.name(), parent);
+		folderProvider.save(targetFolder);
+	}
+
+	@Transactional
+	public void deleteFolder(Long userId, Long folderId) throws ApiFolderException {
+
+		// 삭제하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(folderId);
+		validateFolderAccess(userId, targetFolder);
+
+		// TODO: 삭제된 폴더안의 다른 폴더와 픽들의 부모 설정은 FolderPickFacade에서 미분류로 변경
+		folderProvider.deleteById(folderId);
+	}
+
+	private void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
+
+		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+	}
+
+	private void validateDuplicateFolderName(Long userId, String name) throws ApiFolderException {
+
+		if (folderProvider.existsByUserIdAndName(userId, name)) {
+			throw ApiFolderException.FOLDER_ALREADY_EXIST();
+		}
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateRequest.java
@@ -1,0 +1,7 @@
+package kernel360.techpick.feature.folder.service.dto;
+
+public record FolderCreateRequest(
+	String name,
+	Long parentId
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderResponse.java
@@ -1,0 +1,9 @@
+package kernel360.techpick.feature.folder.service.dto;
+
+public record FolderResponse(
+	Long id,
+	String name,
+	Long parentId,
+	Long userId
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
@@ -1,0 +1,8 @@
+package kernel360.techpick.feature.folder.service.dto;
+
+public record FolderUpdateRequest(
+	Long id,
+	String name,
+	Long parentId
+) {
+}


### PR DESCRIPTION
- Close #115

## What is this PR? 🔍

- 기능 : Folder 서비스 CRUD와 검증로직 구현
- issue : #115

## Changes 📝

### Folder 서비스 CRUD 구현
- `createFolder(Long userId, FolderCreateRequest request)`
- `List<FolderResponse> getFolderListByUserId(Long userId)`
- `List<FolderResponse> getFolderListByParentId(Long userId, Long parentId)`
  - 특정 폴더를 부모로 가지는 폴더 리스트 반환(즉, 특정 폴더의 자식 폴더 리스트 반환)
  - 폴더 세부내용 보기와 폴더구조json 검증에서 사용할 예정
- `void updateFolder(Long userId, FolderUpdateRequest request)`
- `void moveToUnclassified(Long userId, Long folderId)`
  - 특정 폴더를 미분류 폴더로 이동 
- `void moveToRecycleBin(Long userId, Long folderId)`
  - 특정 폴더를 휴지통으로 이동
- `void deleteFolder(Long userId, Long folderId)`
  - 특정 폴더를 삭제 후 해당 폴더의 자식들을 미분류폴더로 이동

### Folder 검증 로직 추가
- `validateFolderAccess(Long userId, Folder folder)` : 특정 폴더가 본인 폴더인지 검증하는 로직
- `validateDuplicateFolderName(Long userId, String name)` : 폴더이름이 중복되는지 검증하는 로직 -본인 폴더들에서만 중복체크

## Precaution

### TODO: 미분류폴더로 이동하는 작업은 `FolderPickFacade`에서 할 예정