### PR TITLE
feat: Pick DTO 설계

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/model/link/Link.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/link/Link.java
@@ -52,14 +52,23 @@ public class Link {
 	@Column(name = "description", columnDefinition = "VARCHAR(600)")
 	private String description;
 
+	@Column(name = "imageUrl", columnDefinition = "VARCHAR(600)")
+	private String imageUrl;
+
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
+	// RSS 또는 관리자가 직접 등록 시 사용
 	public static Link create(String url, String title, String description) {
-		return new Link(url, title, description);
+		return new Link(url, title, description, null);
 	}
 
-	private Link(String url, String title, String description) {
+	public static Link create(String url, String title, String description, String imageUrl) {
+		return new Link(url, title, description, imageUrl);
+	}
+
+	private Link(String url, String title, String description, String imageUrl) {
 		this.url = url;
 		this.title = title;
 		this.description = description;
+		this.imageUrl = imageUrl;
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/pick/Pick.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/pick/Pick.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kernel360.techpick.core.model.common.TimeTracking;
+import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.core.model.link.Link;
 import kernel360.techpick.core.model.user.User;
 import lombok.AccessLevel;
@@ -37,6 +38,10 @@ public class Pick extends TimeTracking {
 	@JoinColumn(name = "link_id", nullable = false)
 	private Link link;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "folder_id", nullable = false)
+	private Folder folder;
+
 	/**
 	 * NOTE: 사용자가 설정한 커스텀 제목
 	 * [#1] 사용자가 저장시 제목을 설정 하지 않았을 경우
@@ -57,9 +62,15 @@ public class Pick extends TimeTracking {
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
 
-	private Pick(User user, Link link, String memo) {
+	private Pick(User user, Link link, Folder folder, String customTitle, String memo) {
 		this.user = user;
 		this.link = link;
+		this.folder = folder;
+		this.customTitle = customTitle;
 		this.memo = memo;
+	}
+
+	public static Pick create(User user, Link link, Folder folder, String customTitle, String memo) {
+		return new Pick(user, link, folder, customTitle, memo);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/pick/Pick.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/pick/Pick.java
@@ -39,8 +39,8 @@ public class Pick extends TimeTracking {
 	private Link link;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "folder_id", nullable = false)
-	private Folder folder;
+	@JoinColumn(name = "parent_folder_id", nullable = false)
+	private Folder parentFolder;
 
 	/**
 	 * NOTE: 사용자가 설정한 커스텀 제목
@@ -62,15 +62,15 @@ public class Pick extends TimeTracking {
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
 
-	private Pick(User user, Link link, Folder folder, String customTitle, String memo) {
+	private Pick(User user, Link link, Folder parentFolder, String customTitle, String memo) {
 		this.user = user;
 		this.link = link;
-		this.folder = folder;
+		this.parentFolder = parentFolder;
 		this.customTitle = customTitle;
 		this.memo = memo;
 	}
 
-	public static Pick create(User user, Link link, Folder folder, String customTitle, String memo) {
-		return new Pick(user, link, folder, customTitle, memo);
+	public static Pick create(User user, Link link, Folder parentFolder, String customTitle, String memo) {
+		return new Pick(user, link, parentFolder, customTitle, memo);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/link/model/LinkMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/link/model/LinkMapper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import kernel360.techpick.core.model.link.Link;
 import kernel360.techpick.feature.link.service.dto.LinkRequest;
 import kernel360.techpick.feature.link.service.dto.LinkResponse;
+import kernel360.techpick.feature.pick.service.dto.PickCreateRequest;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -15,12 +16,19 @@ public class LinkMapper {
 		return Link.create(linkRequest.title(), linkRequest.description(), linkRequest.url());
 	}
 
+	public Link createLink(PickCreateRequest pickCreateRequest) {
+		return Link.create(pickCreateRequest.linkRequest().url(), pickCreateRequest.linkRequest().title(),
+			pickCreateRequest.linkRequest().description(),
+			pickCreateRequest.linkRequest().imageUrl());
+	}
+
 	public LinkResponse createLinkResponse(Link link) {
 		return new LinkResponse(
 			link.getId(),
 			link.getUrl(),
 			link.getTitle(),
-			link.getDescription()
+			link.getDescription(),
+			link.getImageUrl()
 		);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/link/service/dto/LinkRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/link/service/dto/LinkRequest.java
@@ -1,4 +1,4 @@
 package kernel360.techpick.feature.link.service.dto;
 
-public record LinkRequest(String url, String title, String description) {
+public record LinkRequest(String url, String title, String description, String imageUrl) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/link/service/dto/LinkResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/link/service/dto/LinkResponse.java
@@ -1,4 +1,4 @@
 package kernel360.techpick.feature.link.service.dto;
 
-public record LinkResponse(Long id, String url, String title, String description) {
+public record LinkResponse(Long id, String url, String title, String description, String imageUrl) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/pick/exception/ApiPickErrorCode.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/exception/ApiPickErrorCode.java
@@ -1,0 +1,61 @@
+package kernel360.techpick.feature.pick.exception;
+
+import org.springframework.http.HttpStatus;
+
+import kernel360.techpick.core.exception.base.ApiErrorCode;
+import kernel360.techpick.core.exception.level.ErrorLevel;
+
+public enum ApiPickErrorCode implements ApiErrorCode {
+
+	/**
+	 * Pick Error Code (PK)
+	 */
+	PICK_NOT_FOUND
+		("PK-000", HttpStatus.NOT_FOUND, "존재하지 않는 Pick", ErrorLevel.CAN_HAPPEN()),
+	PICK_ALREADY_EXIST
+		("PK-001", HttpStatus.BAD_REQUEST, "이미 존재하는 Pick", ErrorLevel.CAN_HAPPEN()),
+	PICK_UNAUTHORIZED_ACCESS
+		("PK-002", HttpStatus.UNAUTHORIZED, "잘못된 Pick 접근, 다른 사용자의 Pick에 접근", ErrorLevel.SHOULD_NOT_HAPPEN()),
+
+	;
+
+	private final String code;
+
+	private final HttpStatus httpStatus;
+
+	private final String errorMessage;
+
+	private final ErrorLevel logLevel;
+
+	ApiPickErrorCode(String code, HttpStatus status, String message, ErrorLevel errorLevel) {
+		this.code = code;
+		this.httpStatus = status;
+		this.errorMessage = message;
+		this.logLevel = errorLevel;
+	}
+
+	@Override
+	public String getCode() {
+		return this.code;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.errorMessage;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return this.httpStatus;
+	}
+
+	@Override
+	public ErrorLevel getErrorLevel() {
+		return this.logLevel;
+	}
+
+	@Override
+	public String toString() {
+		return convertCodeToString(this);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/exception/ApiPickException.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/exception/ApiPickException.java
@@ -1,0 +1,23 @@
+package kernel360.techpick.feature.pick.exception;
+
+import kernel360.techpick.core.exception.base.ApiErrorCode;
+import kernel360.techpick.core.exception.base.ApiException;
+
+public class ApiPickException extends ApiException {
+
+	private ApiPickException(ApiErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public static ApiPickException PICK_NOT_FOUND() {
+		throw new ApiPickException(ApiPickErrorCode.PICK_NOT_FOUND);
+	}
+
+	public static ApiPickException PICK_ALREADY_EXIST() {
+		throw new ApiPickException(ApiPickErrorCode.PICK_ALREADY_EXIST);
+	}
+
+	public static ApiPickException PICK_UNAUTHORIZED_ACCESS() {
+		throw new ApiPickException(ApiPickErrorCode.PICK_UNAUTHORIZED_ACCESS);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
@@ -1,0 +1,4 @@
+package kernel360.techpick.feature.pick.service;
+
+public class PickService {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickCreateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickCreateRequest.java
@@ -7,7 +7,7 @@ import kernel360.techpick.feature.link.service.dto.LinkRequest;
 public record PickCreateRequest(
 	String memo,
 	String title,
-	List<Long> tagList,
+	List<Long> tagIdList,
 	LinkRequest linkRequest
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickCreateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickCreateRequest.java
@@ -1,0 +1,13 @@
+package kernel360.techpick.feature.pick.service.dto;
+
+import java.util.List;
+
+import kernel360.techpick.feature.link.service.dto.LinkRequest;
+
+public record PickCreateRequest(
+	String memo,
+	String title,
+	List<Long> tagList,
+	LinkRequest linkRequest
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickResponse.java
@@ -1,0 +1,17 @@
+package kernel360.techpick.feature.pick.service.dto;
+
+import java.util.List;
+
+import kernel360.techpick.feature.link.service.dto.LinkResponse;
+import kernel360.techpick.feature.tag.service.dto.TagResponse;
+
+public record PickResponse(
+	Long id,
+	String title,
+	String memo,
+	Long folderId,
+	Long userId,
+	List<TagResponse> tagList,
+	LinkResponse linkResponse
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickTagResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickTagResponse.java
@@ -1,0 +1,8 @@
+package kernel360.techpick.feature.pick.service.dto;
+
+public record PickTagResponse(
+	Long id,
+	Long pickId,
+	Long tagId
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickTagUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickTagUpdateRequest.java
@@ -1,0 +1,10 @@
+package kernel360.techpick.feature.pick.service.dto;
+
+import kernel360.techpick.feature.tag.service.dto.TagResponse;
+
+public record PickTagUpdateRequest(
+	Long id,
+	Long pickId,
+	TagResponse tagResponse // List<TagResponse> or TagResponse
+) {
+}

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickUpdateRequest.java
@@ -6,6 +6,6 @@ public record PickUpdateRequest(
 	Long id,
 	String title,
 	String memo,
-	List<Long> tagList
+	List<Long> tagIdList
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/dto/PickUpdateRequest.java
@@ -1,0 +1,11 @@
+package kernel360.techpick.feature.pick.service.dto;
+
+import java.util.List;
+
+public record PickUpdateRequest(
+	Long id,
+	String title,
+	String memo,
+	List<Long> tagList
+) {
+}

--- a/backend/src/test/java/kernel360/techpick/fixture/LinkFixture.java
+++ b/backend/src/test/java/kernel360/techpick/fixture/LinkFixture.java
@@ -3,8 +3,8 @@ package kernel360.techpick.fixture;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kernel360.techpick.core.model.link.Link;
-import kernel360.techpick.feature.link.model.dto.LinkRequest;
-import kernel360.techpick.feature.link.model.dto.LinkResponse;
+import kernel360.techpick.feature.link.service.dto.LinkRequest;
+import kernel360.techpick.feature.link.service.dto.LinkResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -47,6 +47,7 @@ public class LinkFixture {
 		private @Builder.Default String url = "https://www.test123499.com";
 		private @Builder.Default String title = "Test Title123499";
 		private @Builder.Default String description = "Test Description123499";
+		private @Builder.Default String imageUrl = "https://example.com/images/og-image.jpg";
 
 		public LinkRequest get() {
 			return mapper.convertValue(this, LinkRequest.class);
@@ -71,6 +72,7 @@ public class LinkFixture {
 		private @Builder.Default String url = "https://www.test45390.com";
 		private @Builder.Default String title = "Test Title45390";
 		private @Builder.Default String description = "Test Description45390";
+		private @Builder.Default String imageUrl = "https://example.com/images/og-image.jpg";
 
 		public LinkResponse get() {
 			return mapper.convertValue(this, LinkResponse.class);

--- a/backend/src/test/java/kernel360/techpick/fixture/TagFixture.java
+++ b/backend/src/test/java/kernel360/techpick/fixture/TagFixture.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import kernel360.techpick.core.model.tag.Tag;
 import kernel360.techpick.core.model.user.User;
-import kernel360.techpick.feature.tag.model.dto.TagCreateRequest;
-import kernel360.techpick.feature.tag.model.dto.TagUpdateRequest;
+import kernel360.techpick.feature.tag.service.dto.TagCreateRequest;
+import kernel360.techpick.feature.tag.service.dto.TagUpdateRequest;
 import lombok.Builder;
 import lombok.Getter;
 


### PR DESCRIPTION
- Close #45 

## What is this PR? 🔍

- 기능 : Pick DTO 설계
- issue : #45 

## Changes 📝
- Pick Entity에 Folder 연관 관계 설정
- Pick Error Code, Exception 구현
- Link Entity에 imageUrl 추가
  -  필드 추가에 따라 `linkMapper`, `linkFixture`, `linkRequest`, `linkResponse` 수정
  -  생성 메서드에서 `null` 넣은 것은 rss link를 직접 관리자가 넣어줄 경우에 og:image를 가져올 수 없기 때문
- Pick, PickTag dto 설계 및 구현

## Precaution
dto 구현은 했으나, 추후 수정될 가능성 있음.
프론트 쪽과 얘기한 이후에 정확하게 정의할 예정.

`PickTagUpdateRequest`에 Pick에 포함되어 있는 Tag들은 요청을 리스트로 받게 될 것인지? 하나씩 받게 될 것인지?