### PR TITLE
[REFACTOR] 기본 폴더 CRUD 관련 리팩토링

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -35,7 +35,7 @@ public class Folder extends TimeTracking {
 	private FolderType folderType;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "parent_id")
+	@JoinColumn(name = "parent_folder_id")
 	private Folder parentFolder;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -49,9 +49,9 @@ public class Folder extends TimeTracking {
 		this.user = user;
 	}
 
-	public void update(String name, Folder parent) {
+	public void update(String name, Folder parentFolder) {
 		this.name = name;
-		this.parentFolder = parent;
+		this.parentFolder = parentFolder;
 	}
 
 	public void updateParentFolder(Folder parentFolder) {

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -36,26 +36,26 @@ public class Folder extends TimeTracking {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
-	private Folder parent;
+	private Folder parentFolder;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	private Folder(String name, Folder parent, FolderType folderType, User user) {
+	private Folder(String name, Folder parentFolder, FolderType folderType, User user) {
 		this.name = name;
-		this.parent = parent;
+		this.parentFolder = parentFolder;
 		this.folderType = folderType;
 		this.user = user;
 	}
 
 	public void update(String name, Folder parent) {
 		this.name = name;
-		this.parent = parent;
+		this.parentFolder = parent;
 	}
 
 	public void updateParent(Folder parent) {
-		this.parent = parent;
+		this.parentFolder = parent;
 	}
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/Folder.java
@@ -54,12 +54,12 @@ public class Folder extends TimeTracking {
 		this.parentFolder = parent;
 	}
 
-	public void updateParent(Folder parent) {
-		this.parentFolder = parent;
+	public void updateParentFolder(Folder parentFolder) {
+		this.parentFolder = parentFolder;
 	}
 
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
-	public static Folder create(String name, Folder parent, FolderType folderType, User user) {
-		return new Folder(name, parent, folderType, user);
+	public static Folder create(String name, Folder parentFolder, FolderType folderType, User user) {
+		return new Folder(name, parentFolder, folderType, user);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
@@ -1,5 +1,7 @@
 package kernel360.techpick.core.model.folder;
 
+import java.util.EnumSet;
+
 public enum FolderType {
 
 	UNCLASSIFIED,
@@ -8,4 +10,7 @@ public enum FolderType {
 
 	;
 
+	public static EnumSet<FolderType> getBasicFolderTypes() {
+		return EnumSet.of(UNCLASSIFIED, RECYCLE_BIN);
+	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
@@ -13,7 +13,7 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 	FOLDER_NOT_FOUND("FO-000", HttpStatus.BAD_REQUEST, "존재하지 않는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	FOLDER_ALREADY_EXIST("FO-001", HttpStatus.BAD_REQUEST, "이미 존재하는 폴더 이름", ErrorLevel.CAN_HAPPEN()),
 	FOLDER_ACCESS_DENIED("FO-002", HttpStatus.UNAUTHORIZED, "접근할 수 없는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
-	BASIC_FOLDER_CANNOT_CHANGED("FO-003", HttpStatus.BAD_REQUEST, "기본폴더는 수정 및 삭제할 수 없음",
+	BASIC_FOLDER_CANNOT_CHANGED("FO-003", HttpStatus.BAD_REQUEST, "기본폴더는 변경(수정/삭제/이동)할 수 없음",
 		ErrorLevel.MUST_NEVER_HAPPEN());
 
 	private final String code;

--- a/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
@@ -13,8 +13,8 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 	FOLDER_NOT_FOUND("FO-000", HttpStatus.BAD_REQUEST, "존재하지 않는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	FOLDER_ALREADY_EXIST("FO-001", HttpStatus.BAD_REQUEST, "이미 존재하는 폴더 이름", ErrorLevel.CAN_HAPPEN()),
 	FOLDER_ACCESS_DENIED("FO-002", HttpStatus.UNAUTHORIZED, "접근할 수 없는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
-
-	;
+	BASIC_FOLDER_CANNOT_CHANGED("FO-003", HttpStatus.BAD_REQUEST, "기본폴더는 수정 및 삭제할 수 없음",
+		ErrorLevel.MUST_NEVER_HAPPEN());
 
 	private final String code;
 

--- a/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderException.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderException.java
@@ -23,4 +23,8 @@ public class ApiFolderException extends ApiException {
 	public static ApiFolderException FOLDER_ACCESS_DENIED() {
 		return new ApiFolderException(ApiFolderErrorCode.FOLDER_ACCESS_DENIED);
 	}
+
+	public static ApiFolderException BASIC_FOLDER_CANNOT_CHANGED() {
+		return new ApiFolderException(ApiFolderErrorCode.BASIC_FOLDER_CANNOT_CHANGED);
+	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
@@ -17,9 +17,9 @@ public class FolderMapper {
 
 	private final UserRepository userRepository;
 
-	public Folder createFolder(Long userId, FolderCreateRequest request, Folder parent) throws ApiUserException {
+	public Folder createFolder(Long userId, FolderCreateRequest request, Folder parentFolder) throws ApiUserException {
 		User user = userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
-		return Folder.create(request.name(), parent, FolderType.GENERAL, user);
+		return Folder.create(request.name(), parentFolder, FolderType.GENERAL, user);
 	}
 
 	public FolderResponse createResponse(Folder folder) {

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
@@ -26,7 +26,7 @@ public class FolderMapper {
 		return new FolderResponse(
 			folder.getId(),
 			folder.getName(),
-			folder.getParent().getId(),
+			folder.getParentFolder().getId(),
 			folder.getUser().getId()
 		);
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderProvider.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import kernel360.techpick.core.model.folder.Folder;
-import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.folder.repository.FolderRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,16 +27,16 @@ public class FolderProvider {
 		return folderRepository.findAllByUserId(userId);
 	}
 
-	public List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId) {
-		return folderRepository.findAllByUserIdAndParentId(userId, parentId);
+	public List<Folder> findAllByUserIdAndParentFolderId(Long userId, Long parentFolderId) {
+		return folderRepository.findAllByUserIdAndParentFolderId(userId, parentFolderId);
 	}
 
 	public Folder findUnclassified(Long userId) {
-		return folderRepository.findByUserIdAndFolderType(userId, FolderType.UNCLASSIFIED);
+		return folderRepository.findUnclassifiedByUserId(userId);
 	}
 
 	public Folder findRecycleBin(Long userId) {
-		return folderRepository.findByUserIdAndFolderType(userId, FolderType.RECYCLE_BIN);
+		return folderRepository.findRecycleBinByUserId(userId);
 	}
 
 	public void deleteById(Long folderId) {

--- a/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
@@ -14,7 +14,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 	List<Folder> findAllByUserId(Long userId);
 
-	List<Folder> findAllByUserIdAndParentFolderId(Long userId, Long parentId);
+	List<Folder> findAllByUserIdAndParentFolderId(Long userId, Long parentFolderId);
 
 	// QueryDSL 도입 후 리팩토링 필요
 	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.UNCLASSIFIED")

--- a/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/repository/FolderRepository.java
@@ -3,19 +3,26 @@ package kernel360.techpick.feature.folder.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import kernel360.techpick.core.model.folder.Folder;
-import kernel360.techpick.core.model.folder.FolderType;
 
 @Repository
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 	List<Folder> findAllByUserId(Long userId);
 
-	List<Folder> findAllByUserIdAndParentId(Long userId, Long parentId);
+	List<Folder> findAllByUserIdAndParentFolderId(Long userId, Long parentId);
 
-	Folder findByUserIdAndFolderType(Long userId, FolderType folderType);
+	// QueryDSL 도입 후 리팩토링 필요
+	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.UNCLASSIFIED")
+	Folder findUnclassifiedByUserId(@Param("userId") Long userId);
+
+	// QueryDSL 도입 후 리팩토링 필요
+	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.RECYCLE_BIN")
+	Folder findRecycleBinByUserId(Long userId);
 
 	boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -112,7 +112,7 @@ public class FolderService {
 		// 삭제하려는 폴더가 본인 폴더인지 검증
 		Folder targetFolder = folderProvider.findById(folderId);
 		validateFolderAccess(userId, targetFolder);
-		
+
 		// 삭제하려는 폴더가 기본폴더인지 검증
 		validateChangeBasicFolder(targetFolder);
 
@@ -136,8 +136,7 @@ public class FolderService {
 
 	private void validateChangeBasicFolder(Folder folder) {
 
-		if (FolderType.UNCLASSIFIED == folder.getFolderType() ||
-			FolderType.RECYCLE_BIN == folder.getFolderType()) {
+		if (FolderType.getBasicFolderTypes().contains(folder.getFolderType())) {
 			throw ApiFolderException.BASIC_FOLDER_CANNOT_CHANGED();
 		}
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -27,13 +27,13 @@ public class FolderService {
 	public FolderResponse createFolder(Long userId, FolderCreateRequest request) throws ApiFolderException {
 
 		// 생성하려는 폴더의 부모가 본인 폴더인지 검증
-		Folder parent = folderProvider.findById(request.parentId());
-		validateFolderAccess(userId, parent);
+		Folder parentFolder = folderProvider.findById(request.parentFolderId());
+		validateFolderAccess(userId, parentFolder);
 
 		// 생성하려는 폴더 이름이 중복되는지 검증
 		validateDuplicateFolderName(userId, request.name());
 
-		Folder folder = folderProvider.save(folderMapper.createFolder(userId, request, parent));
+		Folder folder = folderProvider.save(folderMapper.createFolder(userId, request, parentFolder));
 
 		return folderMapper.createResponse(folder);
 	}
@@ -48,9 +48,9 @@ public class FolderService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<FolderResponse> getFolderListByParentId(Long userId, Long parentId) {
+	public List<FolderResponse> getFolderListByParentFolderId(Long userId, Long parentFolderId) {
 
-		return folderProvider.findAllByUserIdAndParentId(userId, parentId)
+		return folderProvider.findAllByUserIdAndParentFolderId(userId, parentFolderId)
 			.stream()
 			.map(folderMapper::createResponse)
 			.toList();
@@ -64,13 +64,13 @@ public class FolderService {
 		validateFolderAccess(userId, targetFolder);
 
 		// 변경하려는 폴더의 부모가 본인 폴더인지 검증
-		Folder parent = folderProvider.findById(request.parentId());
-		validateFolderAccess(userId, parent);
+		Folder parentFolder = folderProvider.findById(request.parentFolderId());
+		validateFolderAccess(userId, parentFolder);
 
 		// 수정하려는 폴더 이름이 중복되는지 검증
 		validateDuplicateFolderName(userId, request.name());
 
-		targetFolder.update(request.name(), parent);
+		targetFolder.update(request.name(), parentFolder);
 		folderProvider.save(targetFolder);
 	}
 
@@ -81,7 +81,7 @@ public class FolderService {
 		Folder targetFolder = folderProvider.findById(folderId);
 		validateFolderAccess(userId, targetFolder);
 
-		targetFolder.updateParent(folderProvider.findUnclassified(userId));
+		targetFolder.updateParentFolder(folderProvider.findUnclassified(userId));
 		folderProvider.save(targetFolder);
 	}
 
@@ -92,7 +92,7 @@ public class FolderService {
 		Folder targetFolder = folderProvider.findById(folderId);
 		validateFolderAccess(userId, targetFolder);
 
-		targetFolder.updateParent(folderProvider.findRecycleBin(userId));
+		targetFolder.updateParentFolder(folderProvider.findRecycleBin(userId));
 		folderProvider.save(targetFolder);
 	}
 

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateRequest.java
@@ -2,6 +2,6 @@ package kernel360.techpick.feature.folder.service.dto;
 
 public record FolderCreateRequest(
 	String name,
-	Long parentId
+	Long parentFolderId
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderResponse.java
@@ -3,7 +3,7 @@ package kernel360.techpick.feature.folder.service.dto;
 public record FolderResponse(
 	Long id,
 	String name,
-	Long parentId,
+	Long parentFolderId,
 	Long userId
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
@@ -3,6 +3,6 @@ package kernel360.techpick.feature.folder.service.dto;
 public record FolderUpdateRequest(
 	Long id,
 	String name,
-	Long parentId
+	Long parentFolderId
 ) {
 }


### PR DESCRIPTION
- Close #122

## What is this PR? 🔍

- 기능 : 기본폴더 CRUD 관련 리팩토링
- issue : #122

## Changes 📝

1. `Folder` 엔티티의 부모폴더를 나타내는 필드명이 `parentFolder`로 변경
관련 메소드 및 필드명에도 `parentFolder`로 변경

2. `FolderType`으로 조회하지 않고, 미분류폴더와 휴지통을 조회하는 메소드를 분리

3. 기본 폴더(미분류폴더, 휴지통)는 수정/삭제 불가능하도록 검증 로직 추가

4. 회원가입시 기본폴더 추가되도록 기능 구현
    - 미분류 폴더 `FolderType.UNCLASSIFIED`
    - 휴지통 `FolderType.RECYCLE_BIN`

## 수정 의도

1. 부모 폴더라는것을 더욱 명확하게 나타내기 위함

2. 기본폴더 조회 시 메소드를 분리하여 명확하게 처리
    - `FolderType`을 파라미터로 받을 경우 NPE 발생 가능성 있음
    - `FolderType.GENERAL`의 경우 결과값이 복수일 수 있음

3. 기본 폴더(미분류폴더, 휴지통)는 수정/삭제/이동이 불가능하도록 검증 로직 추가
    - 기본 폴더의 경우 삭제/수정/이동이 불가능 해야함

4. 회원가입시 기본폴더가 추가되도록 기능 구현
    - 회원가입시 기본폴더가 자동으로 생성되도록 해서, 회원이라면 기본폴더가 항상 존재함을 보장


## Precaution

비즈니스 로직에 심각한 영향을 끼치는 경우가 아니라면 이미 설계된 entity를 수정하는것은 좋지 않다고 생각함