### PR TITLE
[FIX] 불필요한 어노테이션 제거

### DIFF
--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.validation.constraints.NotNull;
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
@@ -120,7 +119,7 @@ public class FolderService {
 		folderProvider.deleteById(folderId);
 	}
 
-	private void validateFolderAccess(Long userId, @NotNull Folder folder) throws ApiFolderException {
+	private void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
 
 		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();


### PR DESCRIPTION
- Close #131

## What is this PR? 🔍

- 기능 : 불필요한 어노테이션 제거
- issue : #131

## Changes 📝

`private void validateFolderAccess(Long userId, @NotNull Folder folder)`
->`private void validateFolderAccess(Long userId, Folder folder)`
내부 로직에서 null 체크를 진행하므로 `@NotNull` 어노테이션 불필요

