### PR TITLE
[FEAT] 기본 폴더로 root 폴더 추가

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/auth/service/CustomOAuth2Service.java
+++ b/backend/src/main/java/kernel360/techpick/core/auth/service/CustomOAuth2Service.java
@@ -85,5 +85,6 @@ public class CustomOAuth2Service extends DefaultOAuth2UserService {
 
 		folderRepository.save(Folder.create("미분류폴더", null, FolderType.UNCLASSIFIED, user));
 		folderRepository.save(Folder.create("휴지통", null, FolderType.RECYCLE_BIN, user));
+		folderRepository.save(Folder.create("최상위폴더", null, FolderType.ROOT, user));
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
@@ -7,10 +7,11 @@ public enum FolderType {
 	UNCLASSIFIED,
 	RECYCLE_BIN,
 	GENERAL,
+	ROOT,
 
 	;
 
 	public static EnumSet<FolderType> getBasicFolderTypes() {
-		return EnumSet.of(UNCLASSIFIED, RECYCLE_BIN);
+		return EnumSet.of(UNCLASSIFIED, RECYCLE_BIN, ROOT);
 	}
 }


### PR DESCRIPTION
- Close #139

## What is this PR? 🔍

- 기능 : 기본 폴더로 root 폴더 추가
- issue : #139

## Changes 📝

- 기본 폴더로 root 폴더 추가
  - `FolderType.ROOT` 추가
  - `BasicFolder EnumSet`에 `ROOT` 추가
- 회원가입시 root 폴더도 자동으로 생성

## Precaution

기본폴더에 대한 내용이 바뀌는것이므로, merge된 이후에 pull 한번씩 해주세요
