### PR TITLE
[FEAT] 로그인 확인용 쿠키 구현

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/auth/Filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/kernel360/techpick/core/auth/Filter/TokenAuthenticationFilter.java
@@ -34,6 +34,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 		if (jwtUtil.isValidToken(token)) {
 			var authentication = convertToAuthentication(token);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
+		} else {
+			// 인증 실패시 techPickLogin 쿠키 삭제
+			Cookie techPickLoginCookie = new Cookie("techPickLogin", null);
+			techPickLoginCookie.setMaxAge(0);
+			response.addCookie(techPickLoginCookie);
 		}
 
 		filterChain.doFilter(request, response);

--- a/backend/src/main/java/kernel360/techpick/core/util/CookieUtil.java
+++ b/backend/src/main/java/kernel360/techpick/core/util/CookieUtil.java
@@ -21,8 +21,17 @@ public class CookieUtil {
 			.domain(".minlife.me")
 			.sameSite("None")
 			.build();
-
 		response.setHeader("Set-Cookie", responseCookie.toString());
+
+		// 로그인 확인용 쿠키 (techPickLogin = true) 추가
+		ResponseCookie techPickLoginCookie = ResponseCookie.from("techPickLogin", "true")
+			.maxAge(maxAge)
+			.path("/")
+			.secure(true)
+			.domain(".minlife.me")
+			.sameSite("None")
+			.build();
+		response.setHeader("Set-Cookie", techPickLoginCookie.toString());
 	}
 
 	//쿠키의 이름을 입력받아 쿠키 삭제


### PR DESCRIPTION
- Close #153

## What is this PR? 🔍

- 기능 : 로그인 확인용 쿠키 구현
- issue : #153

## Changes 📝

- 로그인시 로그인 확인용 쿠키: `techPickLogin` 생성
  - 유효기간은 `access_token`과 동일
  - httpOnly 옵션 false
- 인증 실패시(jwt 없을시) `techPickLogin` 삭제
