### PR TITLE
[FEAT] Folder Api 구현 및 FolderService 리팩토링

### DIFF
--- a/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderApi.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderApi.java
@@ -1,0 +1,67 @@
+package kernel360.techpick.feature.folder.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kernel360.techpick.feature.folder.service.dto.FolderResponse;
+import kernel360.techpick.feature.folder.service.dto.FolderUpdateRequest;
+
+@Tag(name = "폴더 API", description = "폴더 API")
+public interface FolderApi {
+
+	@Operation(
+		summary = "기본 폴더 id 조회",
+		description = "현재 로그인된 사용자의 기본폴더(ROOT, UNCLASSIFIED, RECYCLE_BIN)의 id를 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "기본폴더 id를 정상적으로 조회했습니다."
+		)
+	})
+	ResponseEntity<Map<String, Long>> getBasicFolderIdMap(Authentication auth);
+
+	@Operation(
+		summary = "자식 폴더 조회",
+		description = "특정 폴더에 속한 폴더를 조회합니다. 본인의 폴더가 아니면 403예외가 발생합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "폴더를 정상적으로 조회했습니다."
+		),
+		@ApiResponse(
+			responseCode = "403",
+			description = "접근할 수 없는 폴더입니다."
+		)
+	})
+	ResponseEntity<List<FolderResponse>> getFolderListByParentFolderId(Authentication auth, Long folderId);
+
+	@Operation(
+		summary = "폴더 이름 변경",
+		description = "폴더 이름 변경"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "폴더 이름은 정상적으로 변경했습니다."
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = ""
+		),
+		@ApiResponse(
+			responseCode = "403",
+			description = "접근할 수 없는 폴더입니다."
+		)
+	})
+	ResponseEntity<Void> updateFolderName(Authentication auth, Long folderId, FolderUpdateRequest request);
+
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderApi.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderApi.java
@@ -55,7 +55,7 @@ public interface FolderApi {
 		),
 		@ApiResponse(
 			responseCode = "400",
-			description = ""
+			description = "기본 폴더는 변경할 수 없습니다."
 		),
 		@ApiResponse(
 			responseCode = "403",

--- a/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderController.java
@@ -1,0 +1,53 @@
+package kernel360.techpick.feature.folder.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kernel360.techpick.feature.folder.service.FolderService;
+import kernel360.techpick.feature.folder.service.dto.FolderIdDto;
+import kernel360.techpick.feature.folder.service.dto.FolderResponse;
+import kernel360.techpick.feature.folder.service.dto.FolderUpdateRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/folders")
+public class FolderController implements FolderApi {
+
+	private final FolderService folderService;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<Map<String, Long>> getBasicFolderIdMap(Authentication auth) {
+
+		return ResponseEntity.ok(folderService.getBasicFolderIdMap((Long)auth.getPrincipal()));
+	}
+
+	@Override
+	@GetMapping("/parent/{folderId}")
+	public ResponseEntity<List<FolderResponse>> getFolderListByParentFolderId(Authentication auth,
+		@PathVariable Long folderId) {
+
+		return ResponseEntity.ok(
+			folderService.getFolderListByParentFolderId(FolderIdDto.of(auth, folderId)));
+	}
+
+	@Override
+	@PutMapping("/{folderId}")
+	public ResponseEntity<Void> updateFolderName(Authentication auth, Long folderId,
+		@RequestBody FolderUpdateRequest request) {
+
+		folderService.updateName(FolderIdDto.of(auth, folderId), request);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/controller/FolderController.java
@@ -43,7 +43,7 @@ public class FolderController implements FolderApi {
 
 	@Override
 	@PutMapping("/{folderId}")
-	public ResponseEntity<Void> updateFolderName(Authentication auth, Long folderId,
+	public ResponseEntity<Void> updateFolderName(Authentication auth, @PathVariable Long folderId,
 		@RequestBody FolderUpdateRequest request) {
 
 		folderService.updateName(FolderIdDto.of(auth, folderId), request);

--- a/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/exception/ApiFolderErrorCode.java
@@ -13,7 +13,7 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 
 	FOLDER_NOT_FOUND("FO-000", HttpStatus.BAD_REQUEST, "존재하지 않는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	FOLDER_ALREADY_EXIST("FO-001", HttpStatus.BAD_REQUEST, "이미 존재하는 폴더 이름", ErrorLevel.CAN_HAPPEN()),
-	FOLDER_ACCESS_DENIED("FO-002", HttpStatus.UNAUTHORIZED, "접근할 수 없는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
+	FOLDER_ACCESS_DENIED("FO-002", HttpStatus.FORBIDDEN, "접근할 수 없는 폴더", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	BASIC_FOLDER_CANNOT_CHANGED("FO-003", HttpStatus.BAD_REQUEST, "기본폴더는 변경(수정/삭제/이동)할 수 없음",
 		ErrorLevel.MUST_NEVER_HAPPEN()),
 	CANNOT_DELETE_FOLDER_NOT_IN_RECYCLE_BIN("FO-004", HttpStatus.BAD_REQUEST, "휴지통 안에 있는 폴더만 삭제할 수 있음",

--- a/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/model/FolderMapper.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.core.model.user.User;
-import kernel360.techpick.feature.folder.service.dto.FolderCreateRequest;
+import kernel360.techpick.feature.folder.service.dto.FolderCreateDto;
 import kernel360.techpick.feature.folder.service.dto.FolderResponse;
 import kernel360.techpick.feature.user.UserRepository;
 import kernel360.techpick.feature.user.exception.ApiUserException;
@@ -17,7 +17,7 @@ public class FolderMapper {
 
 	private final UserRepository userRepository;
 
-	public Folder createFolder(Long userId, FolderCreateRequest request, Folder parentFolder) throws ApiUserException {
+	public Folder createFolder(Long userId, FolderCreateDto request, Folder parentFolder) throws ApiUserException {
 		User user = userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
 		return Folder.create(request.name(), parentFolder, FolderType.GENERAL, user);
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderService.java
@@ -3,7 +3,6 @@ package kernel360.techpick.feature.folder.service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +12,10 @@ import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.folder.model.FolderMapper;
 import kernel360.techpick.feature.folder.model.FolderProvider;
-import kernel360.techpick.feature.folder.service.dto.FolderCreateRequest;
-import kernel360.techpick.feature.folder.service.dto.FolderMoveRequest;
+import kernel360.techpick.feature.folder.service.dto.FolderIdDto;
 import kernel360.techpick.feature.folder.service.dto.FolderResponse;
-import kernel360.techpick.feature.folder.service.dto.FolderUpdateNameRequest;
+import kernel360.techpick.feature.folder.service.dto.FolderUpdateRequest;
+import kernel360.techpick.feature.folder.validator.FolderValidator;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,101 +24,7 @@ public class FolderService {
 
 	private final FolderProvider folderProvider;
 	private final FolderMapper folderMapper;
-
-	@Transactional
-	public FolderResponse createFolder(Long userId, FolderCreateRequest request) throws ApiFolderException {
-
-		// 생성하려는 폴더의 부모가 본인 폴더인지 검증
-		Folder parentFolder = folderProvider.findById(request.parentFolderId());
-		validateFolderAccess(userId, parentFolder);
-
-		// 생성하려는 폴더 이름이 중복되는지 검증
-		validateDuplicateFolderName(userId, request.name());
-
-		Folder folder = folderProvider.save(folderMapper.createFolder(userId, request, parentFolder));
-
-		// TODO: Validator 구현 후 structure json 검증 로직 추가
-		// StructureValidator validator = StructureValidator.getValidator(userId);
-		// validator.validateJson(request.json);
-
-		return folderMapper.createResponse(folder);
-	}
-
-	@Transactional(readOnly = true)
-	public List<FolderResponse> getFolderListByUserId(Long userId) {
-
-		return folderProvider.findAllByUserId(userId)
-			.stream()
-			.map(folderMapper::createResponse)
-			.toList();
-	}
-
-	@Transactional(readOnly = true)
-	public List<FolderResponse> getFolderListByParentFolderId(Long userId, Long parentFolderId) {
-
-		return folderProvider.findAllByUserIdAndParentFolderId(userId, parentFolderId)
-			.stream()
-			.map(folderMapper::createResponse)
-			.toList();
-	}
-
-	@Transactional
-	public void updateName(Long userId, FolderUpdateNameRequest request) throws ApiFolderException {
-
-		// 변경하려는 폴더가 본인 폴더인지 검증
-		Folder targetFolder = folderProvider.findById(request.id());
-		validateFolderAccess(userId, targetFolder);
-
-		// 변경하려는 폴더가 기본폴더인지 검증
-		validateChangeBasicFolder(targetFolder);
-
-		targetFolder.updateName(request.name());
-		folderProvider.save(targetFolder);
-
-		// TODO: Validator 구현 후 structure json 검증 로직 추가
-		// StructureValidator validator = StructureValidator.getValidator(userId);
-		// validator.validateJson(request.json);
-	}
-
-	@Transactional
-	public void moveFolder(Long userId, FolderMoveRequest request) throws ApiFolderException {
-
-		// 변경하려는 폴더가 본인 폴더인지 검증
-		Folder targetFolder = folderProvider.findById(request.id());
-		validateFolderAccess(userId, targetFolder);
-
-		// 변경하려는 폴더가 기본폴더인지 검증
-		validateChangeBasicFolder(targetFolder);
-
-		// 변경하려는 폴더의 부모가 본인 폴더인지 검증
-		Folder parentFolder = folderProvider.findById(request.parentFolderId());
-		validateFolderAccess(userId, parentFolder);
-
-		targetFolder.updateParentFolder(parentFolder);
-		folderProvider.save(targetFolder);
-
-		// TODO: Validator 구현 후 structure json 검증 로직 추가
-		// StructureValidator validator = StructureValidator.getValidator(userId);
-		// validator.validateJson(request.json);
-	}
-
-	@Transactional
-	public void deleteFolder(Long userId, Long folderId) throws ApiFolderException {
-
-		// 삭제하려는 폴더가 본인 폴더인지 검증
-		Folder targetFolder = folderProvider.findById(folderId);
-		validateFolderAccess(userId, targetFolder);
-
-		// 삭제하려는 폴더가 휴지통 안에 있는지 검증
-		validateFolderInRecycleBin(targetFolder);
-
-		// @OnDelete(action = OnDeleteAction.CASCADE) 에 의해 해당 폴더를 부모로 가지는 모든 폴더/픽이 삭제됨
-		folderProvider.deleteById(folderId);
-
-		// TODO: Validator 구현 후 structure json 검증 로직 추가
-		// StructureValidator validator = StructureValidator.getValidator(userId);
-		// validator.validateJson(request.json);
-	}
+	private final FolderValidator folderValidator;
 
 	@Transactional(readOnly = true)
 	public Map<String, Long> getBasicFolderIdMap(Long userId) {
@@ -134,31 +39,29 @@ public class FolderService {
 		return idMap;
 	}
 
-	private void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
+	@Transactional(readOnly = true)
+	public List<FolderResponse> getFolderListByParentFolderId(FolderIdDto idDto) {
 
-		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
-			throw ApiFolderException.FOLDER_ACCESS_DENIED();
-		}
+		folderValidator.validateFolderAccess(idDto.getUserId(), folderProvider.findById(idDto.getFolderId()));
+
+		return folderProvider.findAllByUserIdAndParentFolderId(idDto.getUserId(), idDto.getFolderId())
+			.stream()
+			.map(folderMapper::createResponse)
+			.toList();
 	}
 
-	private void validateDuplicateFolderName(Long userId, String name) throws ApiFolderException {
+	@Transactional
+	public void updateName(FolderIdDto idDto, FolderUpdateRequest request) throws ApiFolderException {
 
-		if (folderProvider.existsByUserIdAndName(userId, name)) {
-			throw ApiFolderException.FOLDER_ALREADY_EXIST();
-		}
+		// 변경하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(idDto.getFolderId());
+		folderValidator.validateFolderAccess(idDto.getUserId(), targetFolder);
+
+		// 변경하려는 폴더가 기본폴더인지 검증
+		folderValidator.validateChangeBasicFolder(targetFolder);
+
+		targetFolder.updateName(request.name());
+		folderProvider.save(targetFolder);
 	}
 
-	private void validateChangeBasicFolder(Folder folder) {
-
-		if (FolderType.getBasicFolderTypes().contains(folder.getFolderType())) {
-			throw ApiFolderException.BASIC_FOLDER_CANNOT_CHANGED();
-		}
-	}
-
-	private void validateFolderInRecycleBin(Folder folder) throws ApiFolderException {
-
-		if (folderProvider.findParentBasicFolder(folder.getId()) != FolderType.RECYCLE_BIN) {
-			throw ApiFolderException.CANNOT_DELETE_FOLDER_NOT_IN_RECYCLE_BIN();
-		}
-	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderStructureService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderStructureService.java
@@ -13,7 +13,6 @@ import kernel360.techpick.feature.folder.service.dto.FolderCreateDto;
 import kernel360.techpick.feature.folder.service.dto.FolderDeleteDto;
 import kernel360.techpick.feature.folder.service.dto.FolderIdDto;
 import kernel360.techpick.feature.folder.service.dto.FolderMoveDto;
-import kernel360.techpick.feature.folder.service.dto.FolderResponse;
 import kernel360.techpick.feature.folder.validator.FolderValidator;
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +25,7 @@ public class FolderStructureService {
 	private final FolderValidator folderValidator;
 
 	@Transactional
-	public FolderResponse createFolder(FolderCreateDto createDto) throws ApiFolderException {
+	public Folder createFolder(FolderCreateDto createDto) throws ApiFolderException {
 
 		// 생성하려는 폴더의 부모가 본인 폴더인지 검증
 		Folder parentFolder = folderProvider.findById(createDto.parentFolderId());
@@ -35,9 +34,7 @@ public class FolderStructureService {
 		// 생성하려는 폴더 이름이 중복되는지 검증
 		folderValidator.validateDuplicateFolderName(createDto.userId(), createDto.name());
 
-		Folder folder = folderProvider.save(folderMapper.createFolder(createDto.userId(), createDto, parentFolder));
-
-		return folderMapper.createResponse(folder);
+		return folderProvider.save(folderMapper.createFolder(createDto.userId(), createDto, parentFolder));
 	}
 
 	@Transactional(readOnly = true)
@@ -51,12 +48,9 @@ public class FolderStructureService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<FolderResponse> getFolderListByUserId(Long userId) {
+	public List<Folder> getFolderListByUserId(Long userId) {
 
-		return folderProvider.findAllByUserId(userId)
-			.stream()
-			.map(folderMapper::createResponse)
-			.toList();
+		return folderProvider.findAllByUserId(userId);
 	}
 
 	@Transactional

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderStructureService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/FolderStructureService.java
@@ -1,0 +1,96 @@
+package kernel360.techpick.feature.folder.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.feature.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.folder.model.FolderMapper;
+import kernel360.techpick.feature.folder.model.FolderProvider;
+import kernel360.techpick.feature.folder.service.dto.FolderCreateDto;
+import kernel360.techpick.feature.folder.service.dto.FolderDeleteDto;
+import kernel360.techpick.feature.folder.service.dto.FolderIdDto;
+import kernel360.techpick.feature.folder.service.dto.FolderMoveDto;
+import kernel360.techpick.feature.folder.service.dto.FolderResponse;
+import kernel360.techpick.feature.folder.validator.FolderValidator;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FolderStructureService {
+
+	private final FolderProvider folderProvider;
+	private final FolderMapper folderMapper;
+	private final FolderValidator folderValidator;
+
+	@Transactional
+	public FolderResponse createFolder(FolderCreateDto createDto) throws ApiFolderException {
+
+		// 생성하려는 폴더의 부모가 본인 폴더인지 검증
+		Folder parentFolder = folderProvider.findById(createDto.parentFolderId());
+		folderValidator.validateFolderAccess(createDto.userId(), parentFolder);
+
+		// 생성하려는 폴더 이름이 중복되는지 검증
+		folderValidator.validateDuplicateFolderName(createDto.userId(), createDto.name());
+
+		Folder folder = folderProvider.save(folderMapper.createFolder(createDto.userId(), createDto, parentFolder));
+
+		return folderMapper.createResponse(folder);
+	}
+
+	@Transactional(readOnly = true)
+	public Folder getFolderById(FolderIdDto idDto) throws ApiFolderException {
+
+		// 조회하려는 폴더가 본인 폴더인지 검증
+		Folder folder = folderProvider.findById(idDto.getFolderId());
+		folderValidator.validateFolderAccess(idDto.getUserId(), folder);
+
+		return folder;
+	}
+
+	@Transactional(readOnly = true)
+	public List<FolderResponse> getFolderListByUserId(Long userId) {
+
+		return folderProvider.findAllByUserId(userId)
+			.stream()
+			.map(folderMapper::createResponse)
+			.toList();
+	}
+
+	@Transactional
+	public void moveFolder(FolderMoveDto moveDto) throws ApiFolderException {
+
+		// 변경하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(moveDto.id());
+		folderValidator.validateFolderAccess(moveDto.userId(), targetFolder);
+
+		// 변경하려는 폴더가 기본폴더인지 검증
+		folderValidator.validateChangeBasicFolder(targetFolder);
+
+		// 변경하려는 폴더의 부모가 본인 폴더인지 검증
+		Folder parentFolder = folderProvider.findById(moveDto.parentFolderId());
+		folderValidator.validateFolderAccess(moveDto.userId(), parentFolder);
+
+		// 변경하려는 폴더의 부모가 미분류 폴더가 아닌지 검증
+		folderValidator.validateFolderNotUnclassified(moveDto.userId(), parentFolder);
+
+		targetFolder.updateParentFolder(parentFolder);
+		folderProvider.save(targetFolder);
+	}
+
+	@Transactional
+	public void deleteFolder(FolderDeleteDto deleteDto) throws ApiFolderException {
+
+		// 삭제하려는 폴더가 본인 폴더인지 검증
+		Folder targetFolder = folderProvider.findById(deleteDto.folderId());
+		folderValidator.validateFolderAccess(deleteDto.userId(), targetFolder);
+
+		// 삭제하려는 폴더가 휴지통 안에 있는지 검증
+		folderValidator.validateFolderInRecycleBin(targetFolder);
+
+		// @OnDelete(action = OnDeleteAction.CASCADE) 에 의해 해당 폴더를 부모로 가지는 모든 폴더/픽이 삭제됨
+		folderProvider.deleteById(deleteDto.folderId());
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateDto.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderCreateDto.java
@@ -1,7 +1,7 @@
 package kernel360.techpick.feature.folder.service.dto;
 
-public record FolderMoveRequest(
-	Long id,
+public record FolderCreateDto(
+	Long userId,
 	String name,
 	Long parentFolderId
 ) {

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderDeleteDto.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderDeleteDto.java
@@ -1,7 +1,7 @@
 package kernel360.techpick.feature.folder.service.dto;
 
-public record FolderUpdateNameRequest(
-	Long id,
-	String name
+public record FolderDeleteDto(
+	Long userId,
+	Long folderId
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderIdDto.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderIdDto.java
@@ -1,0 +1,19 @@
+package kernel360.techpick.feature.folder.service.dto;
+
+import org.springframework.security.core.Authentication;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FolderIdDto {
+
+	private Long userId;
+	private Long folderId;
+
+	public static FolderIdDto of(Authentication auth, Long folderId) {
+		return new FolderIdDto((Long)auth.getPrincipal(), folderId);
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderMoveDto.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderMoveDto.java
@@ -1,6 +1,8 @@
 package kernel360.techpick.feature.folder.service.dto;
 
-public record FolderCreateRequest(
+public record FolderMoveDto(
+	Long userId,
+	Long id,
 	String name,
 	Long parentFolderId
 ) {

--- a/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/service/dto/FolderUpdateRequest.java
@@ -1,8 +1,6 @@
 package kernel360.techpick.feature.folder.service.dto;
 
 public record FolderUpdateRequest(
-	Long id,
-	String name,
-	Long parentFolderId
+	String name
 ) {
 }

--- a/backend/src/main/java/kernel360/techpick/feature/folder/validator/FolderValidator.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/validator/FolderValidator.java
@@ -18,7 +18,7 @@ public class FolderValidator {
 
 	public void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
 
-		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
+		if (folder == null || !Objects.equals(userId, folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/folder/validator/FolderValidator.java
+++ b/backend/src/main/java/kernel360/techpick/feature/folder/validator/FolderValidator.java
@@ -1,0 +1,53 @@
+package kernel360.techpick.feature.folder.validator;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import kernel360.techpick.core.model.folder.Folder;
+import kernel360.techpick.core.model.folder.FolderType;
+import kernel360.techpick.feature.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.folder.model.FolderProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FolderValidator {
+
+	private final FolderProvider folderProvider;
+
+	public void validateFolderAccess(Long userId, Folder folder) throws ApiFolderException {
+
+		if (folder == null || Objects.equals(userId, folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+	}
+
+	public void validateDuplicateFolderName(Long userId, String name) throws ApiFolderException {
+
+		if (folderProvider.existsByUserIdAndName(userId, name)) {
+			throw ApiFolderException.FOLDER_ALREADY_EXIST();
+		}
+	}
+
+	public void validateChangeBasicFolder(Folder folder) {
+
+		if (FolderType.getBasicFolderTypes().contains(folder.getFolderType())) {
+			throw ApiFolderException.BASIC_FOLDER_CANNOT_CHANGED();
+		}
+	}
+
+	public void validateFolderInRecycleBin(Folder folder) throws ApiFolderException {
+
+		if (folderProvider.findParentBasicFolder(folder.getId()) != FolderType.RECYCLE_BIN) {
+			throw ApiFolderException.CANNOT_DELETE_FOLDER_NOT_IN_RECYCLE_BIN();
+		}
+	}
+
+	public void validateFolderNotUnclassified(Long userId, Folder folder) throws ApiFolderException {
+
+		if (folder.getFolderType() == FolderType.UNCLASSIFIED) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+	}
+}


### PR DESCRIPTION
- Close #160

## What is this PR? 🔍

- 기능
  - Folder Api 구현
  - FolderService, FolderStructureService 분리
- issue : #160

## Changes 📝

- Folder Api 구현
  - FolderApi
  - FolderController
- FolderService 분리
  - FolderController에서 사용하는 메소드를 FolderService로 분리
  - StructureService에서 사용하는 메소드들을 FolderStructureService로 분리
    - FolderStructureService의 경우 Folder 엔티티를 직접 반환(dto로 변환 안함)
- FolderDto 세분화
  - 메소드 파라미터가 많아져 혼란이 생길 가능성이 있어 dto로 래핑


