### PR TITLE
[FEAT] 픽 중복 조회 기능, 로그아웃 API, CORS 설정 추가

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/auth/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/kernel360/techpick/core/auth/handler/OAuth2SuccessHandler.java
@@ -11,6 +11,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kernel360.techpick.core.auth.model.OAuth2UserInfo;
+import kernel360.techpick.core.config.SecurityConfig;
 import kernel360.techpick.core.model.user.User;
 import kernel360.techpick.core.util.CookieUtil;
 import kernel360.techpick.core.util.JwtUtil;
@@ -24,7 +25,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final JwtUtil jwtUtil;
 	private final UserRepository userRepository;
 	private static final Duration ACCESS_TOKEN_DURATION = Duration.ofDays(1);
-	private static final String ACCESS_TOKEN_KEY = "access_token";
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -53,7 +53,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		int cookieMaxAge = (int)ACCESS_TOKEN_DURATION.toSeconds();
 
-		CookieUtil.deleteCookie(request, response, ACCESS_TOKEN_KEY);
-		CookieUtil.addCookie(response, ACCESS_TOKEN_KEY, refreshToken, cookieMaxAge);
+		CookieUtil.deleteCookie(request, response, SecurityConfig.ACCESS_TOKEN_KEY);
+		CookieUtil.addCookie(response, SecurityConfig.ACCESS_TOKEN_KEY, refreshToken, cookieMaxAge);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/core/config/SecurityConfig.java
+++ b/backend/src/main/java/kernel360/techpick/core/config/SecurityConfig.java
@@ -38,13 +38,13 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		// TODO: 이후 설정 추가 필요
 		http
-			.csrf(AbstractHttpConfigurer::disable)
+			// .csrf(AbstractHttpConfigurer::disable) // csrf 비활성화 시 logout 했을 때 GET 메서드로 요청됨. POST로만 보내도록 하기 위해 주석 처리
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.logout(config -> {
-				config.logoutUrl("/api/logout");
-				config.deleteCookies("JSESSIONID", SecurityConfig.ACCESS_TOKEN_KEY);
+				config.logoutUrl("/api/logout")
+					.deleteCookies("JSESSIONID", SecurityConfig.ACCESS_TOKEN_KEY);
 			})
 			.sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			// TokenAuthenticationFilter 를 UsernamePasswordAuthenticationFilter 앞에 추가

--- a/backend/src/main/java/kernel360/techpick/core/config/SecurityConfig.java
+++ b/backend/src/main/java/kernel360/techpick/core/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
 	@Value("${api.base-url}")
 	private String baseUrl;
 
+	public static final String ACCESS_TOKEN_KEY = "access_token";
+
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		// TODO: 이후 설정 추가 필요
@@ -40,7 +42,10 @@ public class SecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
-			.logout(AbstractHttpConfigurer::disable)
+			.logout(config -> {
+				config.logoutUrl("/api/logout");
+				config.deleteCookies("JSESSIONID", SecurityConfig.ACCESS_TOKEN_KEY);
+			})
 			.sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			// TokenAuthenticationFilter 를 UsernamePasswordAuthenticationFilter 앞에 추가
 			.addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -79,7 +84,8 @@ public class SecurityConfig {
 			baseUrl, /* from env */
 			"https://local.minlife.me:3000" /* Frontend Local */,
 			"https://app.minlife.me" /* Frontend App server */,
-			"chrome-extension://nijonkmmpngclkmeddmgjgdhjefmnmbm" /* Chrome Extension */
+			"chrome-extension://nijonkmmpngclkmeddmgjgdhjefmnmbm", /* Chrome Extension Local */
+			"chrome-extension://bbnefnfpfhiebljiigajahhbbkgndjne" /* Chrome Extension Deploy */
 		));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderType.java
@@ -23,8 +23,4 @@ public enum FolderType {
 	public static EnumSet<FolderType> getBasicFolderTypes() {
 		return EnumSet.of(UNCLASSIFIED, RECYCLE_BIN, ROOT);
 	}
-
-	public static EnumSet<FolderType> getUnclassifiedFolderTypes() {
-		return EnumSet.of(UNCLASSIFIED);
-	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
@@ -30,6 +30,22 @@ public interface PickApi {
 	ResponseEntity<PickResponse> getPickById(Long pickId);
 
 	@Operation(
+		summary = "URL로 픽 조회",
+		description = "URL로 픽 id를 획득합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "픽 id 획득에 성공하였습니다."
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "픽 id가 존재하지 않습니다."
+		)
+	})
+	ResponseEntity<Long> getPickIdByUrl(String url);
+
+	@Operation(
 		summary = "사용자 픽 리스트 조회",
 		description = "사용자가 가진 모든 픽 리스트를 조회합니다."
 	)
@@ -52,18 +68,6 @@ public interface PickApi {
 		)
 	})
 	ResponseEntity<List<PickResponse>> getPickListByParentFolderId(Long parentFolderId);
-
-	@Operation(
-		summary = "미분류 폴더에 있는 픽 리스트 조회",
-		description = "미분류 폴더에 있는 모든 픽 리스트를 조회합니다."
-	)
-	@ApiResponses(value = {
-		@ApiResponse(
-			responseCode = "200",
-			description = "미분류 폴더 픽 리스트 조회에 성공하였습니다."
-		)
-	})
-	ResponseEntity<List<PickResponse>> getPickListByUnclassified(FolderType folderType);
 
 	@Operation(
 		summary = "픽 생성",

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
@@ -43,7 +43,8 @@ public class PickController implements PickApi {
 	}
 
 	@Override
-	public ResponseEntity<Long> getPickIdByUrl(String url) {
+	@GetMapping("/url/{url}")
+	public ResponseEntity<Long> getPickIdByUrl(@PathVariable String url) {
 		return ResponseEntity.ok(pickService.getPickIdByUrl(url));
 	}
 

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
@@ -43,21 +43,15 @@ public class PickController implements PickApi {
 	}
 
 	@Override
+	public ResponseEntity<Long> getPickIdByUrl(String url) {
+		return ResponseEntity.ok(pickService.getPickIdByUrl(url));
+	}
+
+	@Override
 	@GetMapping(params = "parentId")
 	public ResponseEntity<List<PickResponse>> getPickListByParentFolderId(
 		@RequestParam(value = "parentId", required = false) Long parentFolderId) {
 		return ResponseEntity.ok(pickService.getPickListByParentFolderId(parentFolderId));
-	}
-
-	@Override
-	@GetMapping(params = "folderType")
-	public ResponseEntity<List<PickResponse>> getPickListByUnclassified(
-		@RequestParam(required = false, defaultValue = "UNCLASSIFIED") FolderType folderType) {
-		if (FolderType.getUnclassifiedFolderTypes().contains(folderType)) {
-			return ResponseEntity.ok(pickService.getPickListByUnclassified());
-		}
-
-		return ResponseEntity.notFound().build();
 	}
 
 	@Override

--- a/backend/src/main/java/kernel360/techpick/feature/pick/model/PickProvider.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/model/PickProvider.java
@@ -2,6 +2,7 @@ package kernel360.techpick.feature.pick.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,11 @@ public class PickProvider {
 
 	public boolean existsByUserAndLinkUrl(User user, String url) {
 		return pickRepository.existsByUserAndLinkUrl(user, url);
+	}
+
+	public Pick getByUserAndLinkUrl(User user, String url) {
+		return pickRepository.getByUserAndLinkUrl(user, url)
+			.orElseThrow(ApiPickException::PICK_NOT_FOUND);
 	}
 
 	public Pick save(Pick pick) {

--- a/backend/src/main/java/kernel360/techpick/feature/pick/repository/PickRepository.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/repository/PickRepository.java
@@ -1,6 +1,7 @@
 package kernel360.techpick.feature.pick.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -22,4 +23,6 @@ public interface PickRepository extends JpaRepository<Pick, Long> {
 	List<Pick> findAllByUserAndParentFolderFolderType(User user, FolderType folderType);
 
 	boolean existsByUserAndLinkUrl(User user, String url);
+
+	Optional<Pick> getByUserAndLinkUrl(User user, String url);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
@@ -75,11 +75,11 @@ public class PickService {
 		return pickMapper.toPickResponseList(picks, pickTagProvider, tagMapper, linkMapper);
 	}
 
-	// 미분류 폴더에 있는 픽 리스트 조회
 	@Transactional(readOnly = true)
-	public List<PickResponse> getPickListByUnclassified() {
-		List<Pick> picks = pickProvider.findAllByUnclassified(userService.getCurrentUser());
-		return pickMapper.toPickResponseList(picks, pickTagProvider, tagMapper, linkMapper);
+	public Long getPickIdByUrl(String url) {
+		User user = userService.getCurrentUser();
+		Pick pick = pickProvider.getByUserAndLinkUrl(user, url);
+		return pick.getId();
 	}
 
 	// 픽 생성


### PR DESCRIPTION
- Close #204 
## What is this PR? 🔍

- 기능 : 픽 중복 조회 기능, 로그아웃 API, CORS 설정 추가
- issue : #204 

## Changes 📝
- 픽 중복 조회 기능 구현
- 로그아웃 API 기능 구현
  - 스프링 시큐리티 필터에 `/api/logout` 설정, JSESSIONID, access_token 제거
- CORS에 익스텐션 배포용 아이디 추가
- `OAuth2SuccessHandler`에 access_token 상수로 선언된 부분 `SecurityConfig`로 이동

`postman`으로 `/api/logout` `post` 요청 보냈을 때 쿠키 삭제되는 것 확인 완료

## Refactor
logout 할 때 `GET` 요청으로도 로그아웃이 가능한 문제 발생.
`CSRF` 설정 활성화하여 `POST` 요청 시에만 로그아웃이 가능하도록 변경