### PR TITLE
[REFACTOR] url로 Pick 조회 시 리턴 타입 변경

### DIFF
--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.pick.service.dto.PickCreateRequest;
 import kernel360.techpick.feature.pick.service.dto.PickDeleteRequest;
 import kernel360.techpick.feature.pick.service.dto.PickResponse;
@@ -43,7 +42,7 @@ public interface PickApi {
 			description = "픽 id가 존재하지 않습니다."
 		)
 	})
-	ResponseEntity<PickResponse> getPickIdByUrl(String url);
+	ResponseEntity<PickResponse> getPickByUrl(String url);
 
 	@Operation(
 		summary = "사용자 픽 리스트 조회",

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickApi.java
@@ -43,7 +43,7 @@ public interface PickApi {
 			description = "픽 id가 존재하지 않습니다."
 		)
 	})
-	ResponseEntity<Long> getPickIdByUrl(String url);
+	ResponseEntity<PickResponse> getPickIdByUrl(String url);
 
 	@Operation(
 		summary = "사용자 픽 리스트 조회",

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import kernel360.techpick.core.model.folder.FolderType;
 import kernel360.techpick.feature.pick.service.PickService;
 import kernel360.techpick.feature.pick.service.dto.PickCreateRequest;
 import kernel360.techpick.feature.pick.service.dto.PickDeleteRequest;
@@ -44,8 +43,8 @@ public class PickController implements PickApi {
 
 	@Override
 	@GetMapping("/url")
-	public ResponseEntity<PickResponse> getPickIdByUrl(@RequestParam String url) {
-		return ResponseEntity.ok(pickService.getPickIdByUrl(url));
+	public ResponseEntity<PickResponse> getPickByUrl(@RequestParam String url) {
+		return ResponseEntity.ok(pickService.getPickByUrl(url));
 	}
 
 	@Override

--- a/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/controller/PickController.java
@@ -44,7 +44,7 @@ public class PickController implements PickApi {
 
 	@Override
 	@GetMapping("/url")
-	public ResponseEntity<Long> getPickIdByUrl(@RequestParam String url) {
+	public ResponseEntity<PickResponse> getPickIdByUrl(@RequestParam String url) {
 		return ResponseEntity.ok(pickService.getPickIdByUrl(url));
 	}
 

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
@@ -1,7 +1,6 @@
 package kernel360.techpick.feature.pick.service;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,7 +78,7 @@ public class PickService {
 
 	// Url로 픽 상세 조회
 	@Transactional(readOnly = true)
-	public PickResponse getPickIdByUrl(String url) {
+	public PickResponse getPickByUrl(String url) {
 		User user = userService.getCurrentUser();
 		Pick pick = pickProvider.getByUserAndLinkUrl(user, url);
 

--- a/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/pick/service/PickService.java
@@ -77,11 +77,20 @@ public class PickService {
 		return pickMapper.toPickResponseList(picks, pickTagProvider, tagMapper, linkMapper);
 	}
 
+	// Url로 픽 상세 조회
 	@Transactional(readOnly = true)
-	public Long getPickIdByUrl(String url) {
+	public PickResponse getPickIdByUrl(String url) {
 		User user = userService.getCurrentUser();
 		Pick pick = pickProvider.getByUserAndLinkUrl(user, url);
-		return pick.getId();
+
+		// 본인 픽인지 검증 (pickId)
+		pickValidator.validatePickAccess(userService.getCurrentUser(), pick);
+
+		List<PickTag> pickTagList = pickTagProvider.findAllPickTagByPickId(pick.getId());
+		LinkUrlResponse linkUrlResponse = linkMapper.toLinkUrlResponse(pick.getLink());
+		List<TagResponse> tagResponseList = tagMapper.toTagResponse(pickTagList);
+
+		return pickMapper.toPickResponse(pick, tagResponseList, linkUrlResponse);
 	}
 
 	// 픽 생성


### PR DESCRIPTION
- Close #221 

## What is this PR? 🔍

- 기능 : url로 Pick 조회 시 리턴 타입 변경
- issue : #221 

## Changes 📝
url로 Pick 조회 시 리턴 타입 (`Long` -> `PickResponse`)로 변경

프론트에서 Long 타입 반환해주면, 반환된 아이디 값을 가지고 다시 요청을 보내서 가져와야 함.
이 방식을 사용하면, 요청을 2번 보내야 하여 렌더링 시간이 느려지게 됨.
픽 생성 전에 Url로 픽 정보를 조회하여 있으면 수정, 없으면 생성하는데 이 과정에서 리턴 데이터를 활용하려고 함.
리턴된 데이터를 활용하면 렌더링 시간이 빨라지게 됨.