### PR TITLE
[FIX] 익스텐션 태그 중복 생성 차단

### DIFF
--- a/frontend/techpick-extension/src/widgets/TagPicker/TagAutocompleteDialog/index.tsx
+++ b/frontend/techpick-extension/src/widgets/TagPicker/TagAutocompleteDialog/index.tsx
@@ -36,7 +36,9 @@ export function TagAutocompleteDialog({
   const [canCreateTag, setCanCreateTag] = useState(false);
   const tagInputRef = useRef<HTMLInputElement | null>(null);
   const selectedTagListRef = useRef<HTMLDivElement | null>(null);
+  const isCreateFetchPendingRef = useRef<boolean>(false);
   const randomNumber = useRef<number>(getRandomInt());
+
   const {
     tagList,
     selectedTagList,
@@ -64,7 +66,13 @@ export function TagAutocompleteDialog({
   };
 
   const onSelectCreatableTag = async () => {
+    if (isCreateFetchPendingRef.current) {
+      return;
+    }
+
     try {
+      isCreateFetchPendingRef.current = true;
+
       const newTag = await createTag({
         tagName: tagInputValue,
         colorNumber: randomNumber.current,
@@ -75,6 +83,8 @@ export function TagAutocompleteDialog({
       if (error instanceof Error) {
         notifyError(error.message);
       }
+    } finally {
+      isCreateFetchPendingRef.current = false;
     }
   };
 


### PR DESCRIPTION
- Close #253 

## What is this PR? 🔍

- 기능 :
- issue : #253 

## Changes 📝
이제 태그 생성시 연속적으로 입력해서 생성하지 못합니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
