### PR TITLE
[REFACTOR] import 순서 변경

### DIFF
--- a/frontend/techpick/.eslintrc.json
+++ b/frontend/techpick/.eslintrc.json
@@ -5,6 +5,7 @@
     "plugin:storybook/recommended",
     "plugin:storybook/recommended",
     "plugin:react/recommended",
+    "plugin:import/recommended",
     "next/core-web-vitals",
     "prettier"
   ],
@@ -15,6 +16,48 @@
         "varsIgnorePattern": "^_",
         "argsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          ["parent", "sibling", "index"],
+          "type"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "next/**",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "@/types",
+            "group": "type",
+            "position": "after"
+          },
+          {
+            "pattern": "@/schema",
+            "group": "type",
+            "position": "after"
+          },
+          {
+            "pattern": "@/**",
+            "group": "internal"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "newlines-between": "never",
+        "alphabetize": { "order": "asc", "caseInsensitive": true }
+      }
+    ],
+    "import/no-unresolved": "off"
   }
 }

--- a/frontend/techpick/package.json
+++ b/frontend/techpick/package.json
@@ -74,6 +74,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.9",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.35.2",
     "eslint-plugin-storybook": "^0.8.0",
     "husky": "^9.1.6",

--- a/frontend/techpick/src/apis/pick/updatePick/updatePick.ts
+++ b/frontend/techpick/src/apis/pick/updatePick/updatePick.ts
@@ -1,5 +1,5 @@
-import { apiClient, returnErrorFromHTTPError } from '@/apis';
 import { HTTPError } from 'ky';
+import { apiClient, returnErrorFromHTTPError } from '@/apis';
 import type {
   GetPickResponseType,
   UpdatePickRequestType,

--- a/frontend/techpick/src/app/layout.tsx
+++ b/frontend/techpick/src/app/layout.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { ToastProvider, ThemeProvider } from '@/providers';
-import '@/styles/reset.css';
 import { DndProviderWrapper } from '@/providers/DndProviderWrapper';
 import { QueryProvider } from '@/providers/QueryProvider';
+import type { Metadata } from 'next';
+import '@/styles/reset.css';
 
 const inter = Inter({ subsets: ['latin'] });
 export const metadata: Metadata = {

--- a/frontend/techpick/src/app/login/page.tsx
+++ b/frontend/techpick/src/app/login/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
 import Image from 'next/image';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getClientCookie } from '@/utils';
 import {
@@ -11,7 +11,7 @@ import {
   loginContainer,
   loginLink,
   logoContainer,
-} from '@/app/login/page.css';
+} from './page.css';
 
 export default function LoginPage() {
   useEffect(() => {

--- a/frontend/techpick/src/app/page.tsx
+++ b/frontend/techpick/src/app/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 
+import { useEffect, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { NodeApi } from 'react-arborist';
+import { rootLayout } from '@/app/style.css';
 import {
   DirectoryTreeSection,
   LinkEditorSection,
   FeaturedSection,
 } from '@/components';
-import { rootLayout } from '@/app/style.css';
-import { viewContainer, viewWrapper } from './style.css';
-import React, { useEffect, useMemo } from 'react';
-import { NodeApi } from 'react-arborist';
-import { useTreeStore } from '@/stores/treeStore';
-import { useRouter } from 'next/navigation';
-import { getClientCookie } from '@/utils';
 import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
+import { useTreeStore } from '@/stores/treeStore';
+import { getClientCookie } from '@/utils';
+import { viewContainer, viewWrapper } from './style.css';
 
 export default function MainPage() {
   const router = useRouter();

--- a/frontend/techpick/src/components/ContextMenu/EditorContextMenu.tsx
+++ b/frontend/techpick/src/components/ContextMenu/EditorContextMenu.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
 import { ChevronRightIcon } from '@radix-ui/react-icons';
-
+import toast from 'react-hot-toast';
+import { useRestoreNode } from '@/components/nodeManagement/hooks/useRestoreNode';
+import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
+import { useTreeStore } from '@/stores/treeStore';
 import {
   ContextMenuTrigger,
   ContextMenuContent,
@@ -10,10 +13,6 @@ import {
   ContextMenuSubContent,
   ContextMenuSubTrigger,
 } from './ContextMenu.css';
-import { useTreeStore } from '@/stores/treeStore';
-import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
-import { useRestoreNode } from '@/components/nodeManagement/hooks/useRestoreNode';
-import toast from 'react-hot-toast';
 
 interface ContextMenuWrapperProps {
   children: React.ReactNode;

--- a/frontend/techpick/src/components/ContextMenu/TreeContextMenu.tsx
+++ b/frontend/techpick/src/components/ContextMenu/TreeContextMenu.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
-
+import toast from 'react-hot-toast';
+import { useRestoreNode } from '@/components/nodeManagement/hooks/useRestoreNode';
+import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
+import { useTreeStore } from '@/stores/treeStore';
 import {
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
   RightSlot,
 } from './ContextMenu.css';
-import { useTreeStore } from '@/stores/treeStore';
-import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
-import { useRestoreNode } from '@/components/nodeManagement/hooks/useRestoreNode';
-import toast from 'react-hot-toast';
 
 interface ContextMenuWrapperProps {
   children: React.ReactNode;

--- a/frontend/techpick/src/components/DeleteTagDialog/index.tsx
+++ b/frontend/techpick/src/components/DeleteTagDialog/index.tsx
@@ -4,10 +4,10 @@ import { useRef, memo, KeyboardEvent, MouseEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import { useQueryClient } from '@tanstack/react-query';
-import { notifyError } from '@/utils';
 import { Text, Button, Gap } from '@/components';
-import { useTagStore } from '@/stores/tagStore';
 import { useDeleteTagDialogStore } from '@/stores/deleteTagDialogStore';
+import { useTagStore } from '@/stores/tagStore';
+import { notifyError } from '@/utils';
 import { dialogContentStyle, dialogOverlayStyle } from './DeleteTagDialog.css';
 
 export const DeleteTagDialog = memo(function DeleteTagDialog() {

--- a/frontend/techpick/src/components/DirectoryNode/DirectoryNode.css.ts
+++ b/frontend/techpick/src/components/DirectoryNode/DirectoryNode.css.ts
@@ -1,5 +1,5 @@
-import { colorThemeContract, commonThemeContract } from 'techpick-shared';
 import { style } from '@vanilla-extract/css';
+import { colorThemeContract, commonThemeContract } from 'techpick-shared';
 
 export const dirNodeWrapper = style({
   width: '100%',

--- a/frontend/techpick/src/components/DirectoryNode/DirectoryNode.tsx
+++ b/frontend/techpick/src/components/DirectoryNode/DirectoryNode.tsx
@@ -1,3 +1,14 @@
+import Image from 'next/image';
+import { useQueryClient } from '@tanstack/react-query';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { TreeContextMenu } from '@/components';
+import { useCreateFolder } from '@/components/nodeManagement/api/folder/useCreateFolder';
+import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
+import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
+import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
+import { useTreeStore } from '@/stores/treeStore';
+import { ApiStructureData } from '@/types/ApiTypes';
 import { DirectoryNodeProps } from '@/types/NodeData';
 import {
   dirIcFolder,
@@ -7,17 +18,6 @@ import {
   dirNodeWrapperFocused,
   nodeNameInput,
 } from './DirectoryNode.css';
-import Image from 'next/image';
-import { ChevronRight, ChevronDown } from 'lucide-react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useCreateFolder } from '@/components/nodeManagement/api/folder/useCreateFolder';
-import { ApiStructureData } from '@/types/ApiTypes';
-import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
-import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
-import toast from 'react-hot-toast';
-import { useTreeStore } from '@/stores/treeStore';
-import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
-import { TreeContextMenu } from '@/components';
 
 export const DirectoryNode = ({
   node,

--- a/frontend/techpick/src/components/DirectoryTreeSection/DirectoryTreeSection.css.ts
+++ b/frontend/techpick/src/components/DirectoryTreeSection/DirectoryTreeSection.css.ts
@@ -1,5 +1,5 @@
-import { colorThemeContract, commonThemeContract } from 'techpick-shared';
 import { style } from '@vanilla-extract/css';
+import { colorThemeContract, commonThemeContract } from 'techpick-shared';
 
 export const leftSidebarSection = style({
   width: '400px',

--- a/frontend/techpick/src/components/DirectoryTreeSection/DirectoryTreeSection.tsx
+++ b/frontend/techpick/src/components/DirectoryTreeSection/DirectoryTreeSection.tsx
@@ -1,4 +1,30 @@
 import React, { useRef } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { debounce } from 'lodash';
+import {
+  ChevronRight,
+  CircleAlert,
+  Folder,
+  LogOut,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+import { NodeApi, Tree, TreeApi } from 'react-arborist';
+import { useDragDropManager } from 'react-dnd';
+import toast from 'react-hot-toast';
+import useResizeObserver from 'use-resize-observer';
+import { useLogout } from '@/apis/auth';
+import { DirectoryNode } from '@/components';
+import { useGetRootAndRecycleBinData } from '@/components/nodeManagement/api/folder/useGetRootAndRecycleBinData';
+import { useGetPicksByParentId } from '@/components/nodeManagement/api/pick/useGetPicksByParentId';
+import { useTreeHandlers } from '@/components/nodeManagement/hooks/useTreeHandlers';
+import { addNodeToStructure } from '@/components/nodeManagement/utils/addNodeToStructure';
+import { convertPickDataToNodeData } from '@/components/nodeManagement/utils/convertPickDataToNodeData';
+import { useTreeStore } from '@/stores/treeStore';
+import { ApiDefaultFolderIdData, ApiStructureData } from '@/types/ApiTypes';
+import { NodeData } from '@/types/NodeData';
 import {
   directoryLabel,
   directoryLabelContainer,
@@ -21,32 +47,6 @@ import {
   rightIcon,
   unClassifiedLabelContainer,
 } from './DirectoryTreeSection.css';
-import Image from 'next/image';
-import { NodeData } from '@/types/NodeData';
-import { NodeApi, Tree, TreeApi } from 'react-arborist';
-import useResizeObserver from 'use-resize-observer';
-import { useDragDropManager } from 'react-dnd';
-import { useTreeStore } from '@/stores/treeStore';
-import {
-  ChevronRight,
-  CircleAlert,
-  Folder,
-  LogOut,
-  Plus,
-  Trash2,
-} from 'lucide-react';
-import { useGetRootAndRecycleBinData } from '@/components/nodeManagement/api/folder/useGetRootAndRecycleBinData';
-import { useTreeHandlers } from '@/components/nodeManagement/hooks/useTreeHandlers';
-import { DirectoryNode } from '@/components';
-import { useLogout } from '@/apis/auth';
-import { useRouter } from 'next/navigation';
-import toast from 'react-hot-toast';
-import { convertPickDataToNodeData } from '@/components/nodeManagement/utils/convertPickDataToNodeData';
-import { addNodeToStructure } from '@/components/nodeManagement/utils/addNodeToStructure';
-import { useQueryClient } from '@tanstack/react-query';
-import { ApiDefaultFolderIdData, ApiStructureData } from '@/types/ApiTypes';
-import { debounce } from 'lodash';
-import { useGetPicksByParentId } from '@/components/nodeManagement/api/pick/useGetPicksByParentId';
 
 export function DirectoryTreeSection({
   defaultFolderIdData,

--- a/frontend/techpick/src/components/LinkEditorSection/LinkEditor.tsx
+++ b/frontend/techpick/src/components/LinkEditorSection/LinkEditor.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useRef } from 'react';
-
-import { Folder } from '@/components';
-import { useTreeStore } from '@/stores/treeStore';
+import { Folder, PickCard, PickCardGridLayout, TagPicker } from '@/components';
 import { useDropHook } from '@/components/nodeManagement/hooks/useDropHook';
+import { useTreeStore } from '@/stores/treeStore';
 import { folderViewSection } from './LinkEditorSection.css';
-import { PickCard, PickCardGridLayout } from '@/components';
-import { TagPicker } from '@/components';
 
 export const LinkEditor = () => {
   const { treeRef, focusedNode, focusedFolderNodeList, focusedLinkNodeList } =

--- a/frontend/techpick/src/components/LinkEditorSection/index.tsx
+++ b/frontend/techpick/src/components/LinkEditorSection/index.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import { ArrowDownAZ, Search } from 'lucide-react';
+import { NodeApi } from 'react-arborist';
+import { ToggleThemeButton } from '@/components';
+import { useTreeStore } from '@/stores/treeStore';
+import { LinkEditor } from './LinkEditor';
 import {
   linkEditorLabel,
   linkEditorSectionFooter,
@@ -7,11 +12,6 @@ import {
   searchSection,
   linkEditor,
 } from './LinkEditorSection.css';
-import { NodeApi } from 'react-arborist';
-import { ArrowDownAZ, Search } from 'lucide-react';
-import { useTreeStore } from '@/stores/treeStore';
-import { LinkEditor } from './LinkEditor';
-import { ToggleThemeButton } from '@/components';
 
 export function LinkEditorSection() {
   const { focusedNode, treeRef } = useTreeStore();

--- a/frontend/techpick/src/components/PickCard/PickCard.tsx
+++ b/frontend/techpick/src/components/PickCard/PickCard.tsx
@@ -3,7 +3,9 @@
 import { PropsWithChildren } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { NodeApi } from 'react-arborist';
 import { useGetPickQuery } from '@/apis/pick';
+import { useDragHook } from '@/components/nodeManagement/hooks/useDragHook';
 import {
   pickCardLayout,
   cardImageSectionStyle,
@@ -14,8 +16,6 @@ import {
   skeleton,
   linkStyle,
 } from './pickCard.css';
-import { useDragHook } from '@/components/nodeManagement/hooks/useDragHook';
-import { NodeApi } from 'react-arborist';
 
 export function PickCard({ children, node }: PropsWithChildren<PickCardProps>) {
   const {

--- a/frontend/techpick/src/components/SelectedTagItem/SelectedTagContent.css.ts
+++ b/frontend/techpick/src/components/SelectedTagItem/SelectedTagContent.css.ts
@@ -1,6 +1,6 @@
 import { style } from '@vanilla-extract/css';
-import { SelectedTagCommonStyle } from './SelectedTagCommonStyle.css';
 import { color } from 'techpick-shared';
+import { SelectedTagCommonStyle } from './SelectedTagCommonStyle.css';
 
 export const selectedTagContentStyle = style({
   boxSizing: 'border-box',

--- a/frontend/techpick/src/components/SelectedTagItem/SelectedTagItem.tsx
+++ b/frontend/techpick/src/components/SelectedTagItem/SelectedTagItem.tsx
@@ -1,9 +1,9 @@
 import { CSSProperties } from 'react';
-import { numberToRandomColor } from '@/utils';
 import { useThemeStore } from '@/stores/themeStore';
-import { TagType } from '@/types';
+import { numberToRandomColor } from '@/utils';
 import { SelectedTagContent } from './SelectedTagContent';
 import { SelectedTagLayout } from './SelectedTagLayout';
+import { TagType } from '@/types';
 
 export function SelectedTagItem({ tag, children }: SelectedTagItemProps) {
   const { isDarkMode } = useThemeStore();

--- a/frontend/techpick/src/components/SelectedTagItem/SelectedTagLayout.tsx
+++ b/frontend/techpick/src/components/SelectedTagItem/SelectedTagLayout.tsx
@@ -1,5 +1,5 @@
-import { selectedTagLayoutStyle } from './SelectedTagLayout.css';
 import { CSSProperties, ReactNode } from 'react';
+import { selectedTagLayoutStyle } from './SelectedTagLayout.css';
 
 export function SelectedTagLayout({
   style,

--- a/frontend/techpick/src/components/ShowDeleteTagDialogButton.tsx
+++ b/frontend/techpick/src/components/ShowDeleteTagDialogButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Button } from '@/components';
-import type { TagType } from '@/types';
 import { useDeleteTagDialogStore } from '@/stores/deleteTagDialogStore';
+import type { TagType } from '@/types';
 
 export function ShowDeleteTagDialogButton({
   tag,

--- a/frontend/techpick/src/components/TagPicker/TagAutocompleteDialog/index.tsx
+++ b/frontend/techpick/src/components/TagPicker/TagAutocompleteDialog/index.tsx
@@ -4,19 +4,17 @@ import { Dispatch, useEffect, useRef, useState } from 'react';
 import { Command } from 'cmdk';
 import { BarLoader } from 'react-spinners';
 import { color } from 'techpick-shared';
+import { useUpdatePickMutation, useGetPickQuery } from '@/apis/pick';
+import {
+  SelectedTagItem,
+  SelectedTagListLayout,
+  DeleteTagDialog,
+  DeselectTagButton,
+} from '@/components';
+import { useTagStore } from '@/stores/tagStore';
 import { useThemeStore } from '@/stores/themeStore';
 import { notifyError, numberToRandomColor } from '@/utils';
-import { useUpdatePickMutation, useGetPickQuery } from '@/apis/pick';
-import { useTagStore } from '@/stores/tagStore';
-import { SelectedTagItem, SelectedTagListLayout } from '@/components';
-import { DeleteTagDialog, DeselectTagButton } from '@/components';
 import { TagInfoEditPopoverButton } from '../TagInfoEditPopoverButton';
-import { useCalculateCommandListHeight } from './useCalculateCommandListHeight';
-import {
-  filterCommandItems,
-  CREATABLE_TAG_KEYWORD,
-  getRandomInt,
-} from './TagAutocompleteDialog.lib';
 import {
   tagDialogPortalLayout,
   commandInputStyle,
@@ -26,6 +24,12 @@ import {
   tagListStyle,
   tagListLoadingStyle,
 } from './TagAutocompleteDialog.css';
+import {
+  filterCommandItems,
+  CREATABLE_TAG_KEYWORD,
+  getRandomInt,
+} from './TagAutocompleteDialog.lib';
+import { useCalculateCommandListHeight } from './useCalculateCommandListHeight';
 import type { TagType } from '@/types';
 
 export function TagAutocompleteDialog({

--- a/frontend/techpick/src/components/TagPicker/TagInfoEditPopoverButton/index.tsx
+++ b/frontend/techpick/src/components/TagPicker/TagInfoEditPopoverButton/index.tsx
@@ -3,18 +3,18 @@
 import { Dispatch, useRef, useState } from 'react';
 import { useFloating, shift } from '@floating-ui/react';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+import { useQueryClient } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
-import { notifyError } from '@/utils';
-import { useTagStore } from '@/stores/tagStore';
 import { ShowDeleteTagDialogButton } from '@/components';
-import { PopoverTriggerButton } from './PopoverTriggerButton';
+import { useTagStore } from '@/stores/tagStore';
+import { notifyError } from '@/utils';
 import { PopoverOverlay } from './PopoverOverlay';
-import { isEmptyString, isSameValue } from './TagInfoEditPopoverButton.lib';
+import { PopoverTriggerButton } from './PopoverTriggerButton';
 import {
   tagInfoEditFormLayout,
   tagInputStyle,
 } from './TagInfoEditPopoverButton.css';
-import { useQueryClient } from '@tanstack/react-query';
+import { isEmptyString, isSameValue } from './TagInfoEditPopoverButton.lib';
 import { TagType } from '@/types';
 
 export function TagInfoEditPopoverButton({

--- a/frontend/techpick/src/components/TagPicker/index.tsx
+++ b/frontend/techpick/src/components/TagPicker/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { forwardRef, useEffect, useRef, useState } from 'react';
-import { SelectedTagItem, SelectedTagListLayout } from '@/components';
 import { useGetPickQuery } from '@/apis/pick';
+import { SelectedTagItem, SelectedTagListLayout } from '@/components';
 import { TagAutocompleteDialog } from './TagAutocompleteDialog';
 import { tagPickerLayout, tagDialogTriggerLayout } from './TagPicker.css';
 import type { TagType } from '@/types';

--- a/frontend/techpick/src/components/ToggleThemeButton.tsx
+++ b/frontend/techpick/src/components/ToggleThemeButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React from 'react';
-import { useThemeStore } from '@/stores/themeStore';
 import { Moon, Sun } from 'lucide-react';
+import { useThemeStore } from '@/stores/themeStore';
 
 export function ToggleThemeButton() {
   const { isDarkMode, toggleTheme } = useThemeStore();

--- a/frontend/techpick/src/components/nodeManagement/api/folder/folderQueryFunctions.ts
+++ b/frontend/techpick/src/components/nodeManagement/api/folder/folderQueryFunctions.ts
@@ -1,5 +1,5 @@
-import { ApiDefaultFolderIdData, ApiStructureData } from '@/types/ApiTypes';
 import { apiClient } from '@/apis/apiClient';
+import { ApiDefaultFolderIdData, ApiStructureData } from '@/types/ApiTypes';
 
 export const getRootAndRecycleBinData = async (): Promise<ApiStructureData> => {
   try {

--- a/frontend/techpick/src/components/nodeManagement/api/folder/useCreateFolder.ts
+++ b/frontend/techpick/src/components/nodeManagement/api/folder/useCreateFolder.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
-import { ApiFolderData } from '@/types/ApiTypes';
 import { postFolder } from '@/components/nodeManagement/api/folder/folderQueryFunctions';
+import { ApiFolderData } from '@/types/ApiTypes';
 
 export const useCreateFolder = () => {
   return useMutation<ApiFolderData, Error, string>({

--- a/frontend/techpick/src/components/nodeManagement/api/folder/useGetDefaultFolderData.ts
+++ b/frontend/techpick/src/components/nodeManagement/api/folder/useGetDefaultFolderData.ts
@@ -1,6 +1,6 @@
-import { ApiDefaultFolderIdData } from '@/types/ApiTypes';
 import { useQuery } from '@tanstack/react-query';
 import { getFoldersIdData } from '@/components/nodeManagement/api/folder/folderQueryFunctions';
+import { ApiDefaultFolderIdData } from '@/types/ApiTypes';
 
 export const useGetDefaultFolderData = () => {
   return useQuery<ApiDefaultFolderIdData>({

--- a/frontend/techpick/src/components/nodeManagement/api/pick/useCreatePick.ts
+++ b/frontend/techpick/src/components/nodeManagement/api/pick/useCreatePick.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
-import { ApiPickData, ApiPickRequestType } from '@/types/ApiTypes';
 import { postPick } from '@/components/nodeManagement/api/pick/pickQueryFunctions';
+import { ApiPickData, ApiPickRequestType } from '@/types/ApiTypes';
 
 export const useCreatePick = () => {
   return useMutation<ApiPickData, Error, ApiPickRequestType>({

--- a/frontend/techpick/src/components/nodeManagement/api/pick/useGetPicksByParentId.ts
+++ b/frontend/techpick/src/components/nodeManagement/api/pick/useGetPicksByParentId.ts
@@ -1,5 +1,5 @@
-import { getPicksByParentId } from '@/components/nodeManagement/api/pick/pickQueryFunctions';
 import { useQuery } from '@tanstack/react-query';
+import { getPicksByParentId } from '@/components/nodeManagement/api/pick/pickQueryFunctions';
 import { ApiPickData } from '@/types/ApiTypes';
 
 export const useGetPicksByParentId = (parentId: string) => {

--- a/frontend/techpick/src/components/nodeManagement/hooks/useDragHook.ts
+++ b/frontend/techpick/src/components/nodeManagement/hooks/useDragHook.ts
@@ -1,13 +1,14 @@
-import { NodeApi } from 'react-arborist';
-import { ConnectDragSource, useDrag } from 'react-dnd';
-import { DragItem } from 'react-arborist/dist/main/types/dnd';
-import { actions as dnd } from 'react-arborist/dist/main/state/dnd-slice';
-import { DropResult } from 'react-arborist/dist/main/dnd/drop-hook';
-import { safeRun } from 'react-arborist/dist/main/utils';
-import { ROOT_ID } from 'react-arborist/dist/main/data/create-root';
 import { useEffect } from 'react';
+import { NodeApi } from 'react-arborist';
+import { ROOT_ID } from 'react-arborist/dist/main/data/create-root';
+import { DropResult } from 'react-arborist/dist/main/dnd/drop-hook';
+import { actions as dnd } from 'react-arborist/dist/main/state/dnd-slice';
+import { DragItem } from 'react-arborist/dist/main/types/dnd';
+import { safeRun } from 'react-arborist/dist/main/utils';
+import { useDrag } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useTreeStore } from '@/stores/treeStore';
+import type { ConnectDragSource } from 'react-dnd';
 
 export function useDragHook(node: NodeApi): ConnectDragSource {
   const { treeRef } = useTreeStore();

--- a/frontend/techpick/src/components/nodeManagement/hooks/useDropHook.ts
+++ b/frontend/techpick/src/components/nodeManagement/hooks/useDropHook.ts
@@ -1,10 +1,11 @@
 import { RefObject } from 'react';
-import { ConnectDropTarget, useDrop } from 'react-dnd';
-import { DragItem } from 'react-arborist/dist/main/types/dnd';
-import { computeDrop } from 'react-arborist/dist/main/dnd/compute-drop';
-import { actions as dnd } from 'react-arborist/dist/main/state/dnd-slice';
 import { NodeApi } from 'react-arborist';
+import { computeDrop } from 'react-arborist/dist/main/dnd/compute-drop';
 import { NodeApi as ArboristNodeApi } from 'react-arborist/dist/main/interfaces/node-api';
+import { actions as dnd } from 'react-arborist/dist/main/state/dnd-slice';
+import { DragItem } from 'react-arborist/dist/main/types/dnd';
+import { useDrop } from 'react-dnd';
+import type { ConnectDropTarget } from 'react-dnd';
 
 export type DropResult = {
   parentId: string | null;

--- a/frontend/techpick/src/components/nodeManagement/hooks/useRestoreNode.ts
+++ b/frontend/techpick/src/components/nodeManagement/hooks/useRestoreNode.ts
@@ -1,10 +1,10 @@
-import { removeByIdFromStructure } from '@/components/nodeManagement/utils/removeByIdFromStructure';
-import { NodeApi } from 'react-arborist';
-import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
 import { useQueryClient } from '@tanstack/react-query';
-import { ApiStructureData } from '@/types/ApiTypes';
+import { NodeApi } from 'react-arborist';
 import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
+import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
 import { useMovePick } from '@/components/nodeManagement/api/pick/useMovePick';
+import { removeByIdFromStructure } from '@/components/nodeManagement/utils/removeByIdFromStructure';
+import { ApiStructureData } from '@/types/ApiTypes';
 
 export const useRestoreNode = () => {
   const { mutateAsync: moveFolder } = useMoveFolder();

--- a/frontend/techpick/src/components/nodeManagement/hooks/useTreeHandlers.ts
+++ b/frontend/techpick/src/components/nodeManagement/hooks/useTreeHandlers.ts
@@ -1,21 +1,22 @@
-import { NodeData } from '@/types';
-import { createNode } from '@/components/nodeManagement/utils/createNode';
-import { moveNode } from '@/components/nodeManagement/utils/moveNode';
-import { useGetRootAndRecycleBinData } from '@/components/nodeManagement/api/folder/useGetRootAndRecycleBinData';
-import { useTreeStore } from '@/stores/treeStore';
-import { CreateHandler, MoveHandler, NodeApi } from 'react-arborist';
-import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
-import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
-import { useRenameFolder } from '@/components/nodeManagement/api/folder/useRenameFolder';
-import { removeByIdFromStructure } from '@/components/nodeManagement/utils/removeByIdFromStructure';
-import { getNewIdFromStructure } from '@/components/nodeManagement/utils/getNewIdFromStructure';
 import { useQueryClient } from '@tanstack/react-query';
-import { ApiStructureData } from '@/types/ApiTypes';
+import { NodeApi } from 'react-arborist';
 import toast from 'react-hot-toast';
-import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
 import { deleteFolder } from '@/components/nodeManagement/api/folder/folderQueryFunctions';
-import { useMovePick } from '@/components/nodeManagement/api/pick/useMovePick';
+import { useGetDefaultFolderData } from '@/components/nodeManagement/api/folder/useGetDefaultFolderData';
+import { useGetRootAndRecycleBinData } from '@/components/nodeManagement/api/folder/useGetRootAndRecycleBinData';
+import { useMoveFolder } from '@/components/nodeManagement/api/folder/useMoveFolder';
+import { useRenameFolder } from '@/components/nodeManagement/api/folder/useRenameFolder';
 import { deletePick } from '@/components/nodeManagement/api/pick/pickQueryFunctions';
+import { useMovePick } from '@/components/nodeManagement/api/pick/useMovePick';
+import { createNode } from '@/components/nodeManagement/utils/createNode';
+import { getCurrentTreeTypeByNode } from '@/components/nodeManagement/utils/getCurrentTreeTypeByNode';
+import { getNewIdFromStructure } from '@/components/nodeManagement/utils/getNewIdFromStructure';
+import { moveNode } from '@/components/nodeManagement/utils/moveNode';
+import { removeByIdFromStructure } from '@/components/nodeManagement/utils/removeByIdFromStructure';
+import { useTreeStore } from '@/stores/treeStore';
+import { ApiStructureData } from '@/types/ApiTypes';
+import type { CreateHandler, MoveHandler } from 'react-arborist';
+import { NodeData } from '@/types';
 
 export const useTreeHandlers = () => {
   const { data: structureData, refetch: refetchStructure } =

--- a/frontend/techpick/src/components/nodeManagement/ui/Folder.tsx
+++ b/frontend/techpick/src/components/nodeManagement/ui/Folder.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Image from 'next/image';
+import { NodeApi } from 'react-arborist';
+import { useDragHook } from '@/components/nodeManagement/hooks/useDragHook';
 import {
   folderWrapper,
   folderWrapperFocused,
 } from '@/components/nodeManagement/ui/folder.css';
-import { NodeApi } from 'react-arborist';
-import { useDragHook } from '@/components/nodeManagement/hooks/useDragHook';
 import { useTreeStore } from '@/stores/treeStore';
 
 export function Folder({ node }: { node: NodeApi }) {

--- a/frontend/techpick/src/components/nodeManagement/ui/Pick.tsx
+++ b/frontend/techpick/src/components/nodeManagement/ui/Pick.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { NodeApi } from 'react-arborist';
-
 import Image from 'next/image';
-import { linkWrapper } from '@/components/nodeManagement/ui/pick.css';
+import { NodeApi } from 'react-arborist';
 import { useDragHook } from '@/components/nodeManagement/hooks/useDragHook';
+import { linkWrapper } from '@/components/nodeManagement/ui/pick.css';
 
 // 여기에 PickCard카드될 예정입니다.
 export function Pick({ node }: { node: NodeApi }) {

--- a/frontend/techpick/src/components/nodeManagement/ui/folder.css.ts
+++ b/frontend/techpick/src/components/nodeManagement/ui/folder.css.ts
@@ -1,5 +1,5 @@
-import { commonThemeContract } from 'techpick-shared';
 import { style } from '@vanilla-extract/css';
+import { commonThemeContract } from 'techpick-shared';
 
 export const folderWrapper = style({
   display: 'flex',

--- a/frontend/techpick/src/components/nodeManagement/ui/pick.css.ts
+++ b/frontend/techpick/src/components/nodeManagement/ui/pick.css.ts
@@ -1,5 +1,5 @@
-import { commonThemeContract } from 'techpick-shared';
 import { style } from '@vanilla-extract/css';
+import { commonThemeContract } from 'techpick-shared';
 
 export const linkWrapper = style({
   display: 'flex',

--- a/frontend/techpick/src/components/nodeManagement/utils/addRecycleBinToStructure.ts
+++ b/frontend/techpick/src/components/nodeManagement/utils/addRecycleBinToStructure.ts
@@ -1,7 +1,7 @@
-import { NodeData } from '@/types';
 import { addNodeToStructure } from '@/components/nodeManagement/utils/addNodeToStructure';
 import { getNewIdFromStructure } from '@/components/nodeManagement/utils/getNewIdFromStructure';
 import { ApiStructureData } from '@/types/ApiTypes';
+import { NodeData } from '@/types';
 
 export function addRecycleBinToStructure(
   structure: ApiStructureData,

--- a/frontend/techpick/src/components/nodeManagement/utils/convertPickDataToNodeData.ts
+++ b/frontend/techpick/src/components/nodeManagement/utils/convertPickDataToNodeData.ts
@@ -1,5 +1,5 @@
-import { ApiPickData, ApiStructureData } from '@/types/ApiTypes';
 import { getNewIdFromStructure } from '@/components/nodeManagement/utils/getNewIdFromStructure';
+import { ApiPickData, ApiStructureData } from '@/types/ApiTypes';
 import { NodeData } from '@/types';
 
 export function convertPickDataToNodeData(

--- a/frontend/techpick/src/components/nodeManagement/utils/createNode.ts
+++ b/frontend/techpick/src/components/nodeManagement/utils/createNode.ts
@@ -1,7 +1,7 @@
 import { NodeApi } from 'react-arborist';
-import { NodeData } from '@/types';
 import { getNewIdFromStructure } from '@/components/nodeManagement/utils/getNewIdFromStructure';
 import { ApiStructureData } from '@/types/ApiTypes';
+import { NodeData } from '@/types';
 
 export const createNode = (
   structureData: ApiStructureData,

--- a/frontend/techpick/src/components/nodeManagement/utils/getNewIdFromStructure.ts
+++ b/frontend/techpick/src/components/nodeManagement/utils/getNewIdFromStructure.ts
@@ -1,5 +1,5 @@
-import { NodeData } from '@/types';
 import { ApiStructureData } from '@/types/ApiTypes';
+import { NodeData } from '@/types';
 
 function getMaxIdFromNodes(nodes: NodeData[]): number {
   let maxId = 0;

--- a/frontend/techpick/src/components/nodeManagement/utils/moveNode.ts
+++ b/frontend/techpick/src/components/nodeManagement/utils/moveNode.ts
@@ -1,5 +1,5 @@
-import { NodeData } from '@/types';
 import { NodeApi } from 'react-arborist';
+import { NodeData } from '@/types';
 
 export const moveNode = (
   data: NodeData[],

--- a/frontend/techpick/src/providers/DndProviderWrapper.tsx
+++ b/frontend/techpick/src/providers/DndProviderWrapper.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import React from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import React from 'react';
 
 export const DndProviderWrapper = ({
   children,

--- a/frontend/techpick/src/providers/QueryProvider.tsx
+++ b/frontend/techpick/src/providers/QueryProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient();

--- a/frontend/techpick/src/providers/ThemeProvider.tsx
+++ b/frontend/techpick/src/providers/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { useThemeStore } from '@/stores/themeStore';
 import { lightTheme, darkTheme, commonTheme } from 'techpick-shared';
+import { useThemeStore } from '@/stores/themeStore';
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const { isDarkMode } = useThemeStore();
 

--- a/frontend/techpick/src/stores/tagStore.ts
+++ b/frontend/techpick/src/stores/tagStore.ts
@@ -1,9 +1,9 @@
+import { HTTPError } from 'ky';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { HTTPError } from 'ky';
 import { handleHTTPError } from '@/apis';
-import type { TagType, TagUpdateType, CreateTagRequestType } from '@/types';
 import { getTagList, createTag, deleteTag, updateTag } from '@/apis/tag';
+import type { TagType, TagUpdateType, CreateTagRequestType } from '@/types';
 
 type TagState = {
   tagList: TagType[];

--- a/frontend/techpick/src/stores/treeStore.ts
+++ b/frontend/techpick/src/stores/treeStore.ts
@@ -1,8 +1,8 @@
-import { create } from 'zustand';
-import { NodeData } from '@/types';
-import { NodeApi, TreeApi } from 'react-arborist';
 import React, { createRef } from 'react';
+import { NodeApi, TreeApi } from 'react-arborist';
+import { create } from 'zustand';
 import { ApiDefaultFolderIdData, ApiPickData } from '@/types/ApiTypes';
+import { NodeData } from '@/types';
 
 interface TreeState {
   treeData: NodeData[];

--- a/frontend/techpick/src/types/NodeData.ts
+++ b/frontend/techpick/src/types/NodeData.ts
@@ -1,5 +1,5 @@
-import { NodeApi } from 'react-arborist';
 import { CSSProperties } from 'react';
+import { NodeApi } from 'react-arborist';
 
 export interface NodeData {
   id: string;

--- a/frontend/techpick/tests/example.spec.ts
+++ b/frontend/techpick/tests/example.spec.ts
@@ -14,6 +14,7 @@ test('get started link', async ({ page }) => {
   await page.getByRole('link', { name: 'Get started' }).click();
 
   // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
-
+  await expect(
+    page.getByRole('heading', { name: 'Installation' })
+  ).toBeVisible();
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8332,7 +8332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.28.1":
+"eslint-plugin-import@npm:^2.28.1, eslint-plugin-import@npm:^2.31.0":
   version: 2.31.0
   resolution: "eslint-plugin-import@npm:2.31.0"
   dependencies:
@@ -14551,6 +14551,7 @@ __metadata:
     eslint: "npm:^8"
     eslint-config-next: "npm:14.2.9"
     eslint-config-prettier: "npm:^9.1.0"
+    eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-react: "npm:^7.35.2"
     eslint-plugin-storybook: "npm:^0.8.0"
     husky: "npm:^9.1.6"


### PR DESCRIPTION
- Close #292 

## What is this PR? 🔍
- issue : #292 

## Changes 📝
- eslint로 import 순서를 변경. 이제 명시된 순서로 import문이 자동 정렬됨.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
