### PR TITLE
[REFACTOR] Folder 도메인 리팩토링

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
@@ -3,8 +3,13 @@ package kernel360.techpick.core.model.folder;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
-	List<Folder> findByParentFolder(Folder parentFolder);
+	List<Folder> findByParentFolderId(Long parentFolderId);
+
+	// TODO: Field 함수는 MySQL계열에서만 제공되므로, 이후 QueryDSL로 리팩토링 필요
+	@Query("select f from Folder f where f.id in :idList order by FIELD(f.id,:idList)")
+	List<Folder> findAllByIdListOrdered(List<Long> idList);
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
@@ -12,4 +13,16 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	// TODO: Field 함수는 MySQL계열에서만 제공되므로, 이후 QueryDSL로 리팩토링 필요
 	@Query("select f from Folder f where f.id in :idList order by FIELD(f.id,:idList)")
 	List<Folder> findAllByIdListOrdered(List<Long> idList);
+
+	// TODO: QueryDSL 도입 후 리팩토링 필요
+	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.UNCLASSIFIED")
+	Folder findUnclassifiedByUserId(@Param("userId") Long userId);
+
+	// TODO: QueryDSL 도입 후 리팩토링 필요
+	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.RECYCLE_BIN")
+	Folder findRecycleBinByUserId(@Param("userId") Long userId);
+
+	// TODO: QueryDSL 도입 후 리팩토링 필요
+	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.ROOT")
+	Folder findRootByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
+++ b/backend/src/main/java/kernel360/techpick/core/model/folder/FolderRepository.java
@@ -10,10 +10,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
 	List<Folder> findByParentFolderId(Long parentFolderId);
 
-	// TODO: Field 함수는 MySQL계열에서만 제공되므로, 이후 QueryDSL로 리팩토링 필요
-	@Query("select f from Folder f where f.id in :idList order by FIELD(f.id,:idList)")
-	List<Folder> findAllByIdListOrdered(List<Long> idList);
-
 	// TODO: QueryDSL 도입 후 리팩토링 필요
 	@Query("SELECT f FROM Folder f WHERE f.user.id = :userId AND f.folderType = kernel360.techpick.core.model.folder.FolderType.UNCLASSIFIED")
 	Folder findUnclassifiedByUserId(@Param("userId") Long userId);

--- a/backend/src/main/java/kernel360/techpick/feature/api/folder/dto/FolderApiMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/folder/dto/FolderApiMapper.java
@@ -5,7 +5,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
 import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
-import kernel360.techpick.feature.domain.folder.dto.FolderResult;
 
 @Mapper(
 	componentModel = "spring",
@@ -13,17 +12,13 @@ import kernel360.techpick.feature.domain.folder.dto.FolderResult;
 	unmappedTargetPolicy = ReportingPolicy.ERROR
 )
 public interface FolderApiMapper {
-	FolderCommand.Create toCreateCommand(FolderApiRequest.Create request);
+	FolderCommand.Create toCreateCommand(Long userId, FolderApiRequest.Create request);
 
-	FolderCommand.Read toReadCommand(FolderApiRequest.Read request);
+	FolderCommand.Read toReadCommand(Long userId, FolderApiRequest.Read request);
 
-	FolderCommand.Update toUpdateCommand(FolderApiRequest.Update request);
+	FolderCommand.Update toUpdateCommand(Long userId, FolderApiRequest.Update request);
 
-	FolderCommand.Move toMoveCommand(FolderApiRequest.Move request);
+	FolderCommand.Move toMoveCommand(Long userId, FolderApiRequest.Move request);
 
-	FolderCommand.Delete toDeleteCommand(FolderApiRequest.Delete request);
-
-	FolderApiResponse.Create toCreateResponse(FolderResult request);
-
-	FolderApiResponse.Read toReadResponse(FolderResult request);
+	FolderCommand.Delete toDeleteCommand(Long userId, FolderApiRequest.Delete request);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/api/folder/dto/FolderApiRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/folder/dto/FolderApiRequest.java
@@ -1,5 +1,7 @@
 package kernel360.techpick.feature.api.folder.dto;
 
+import java.util.List;
+
 public class FolderApiRequest {
 
 	public record Create(
@@ -21,14 +23,14 @@ public class FolderApiRequest {
 	}
 
 	public record Move(
-		Long folderId,
-		Long parentFolderId,
+		List<Long> folderIdList,
+		Long destinationFolderId,
 		int orderIdx
 	) {
 	}
 
 	public record Delete(
-		Long folderId
+		List<Long> folderIdList
 	) {
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/application/FolderFacade.java
+++ b/backend/src/main/java/kernel360/techpick/feature/application/FolderFacade.java
@@ -1,4 +1,0 @@
-package kernel360.techpick.feature.application;
-
-public class FolderFacade {
-}

--- a/backend/src/main/java/kernel360/techpick/feature/application/TagFacade.java
+++ b/backend/src/main/java/kernel360/techpick/feature/application/TagFacade.java
@@ -1,4 +1,0 @@
-package kernel360.techpick.feature.application;
-
-public class TagFacade {
-}

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/dto/FolderCommand.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/dto/FolderCommand.java
@@ -3,21 +3,25 @@ package kernel360.techpick.feature.domain.folder.dto;
 public class FolderCommand {
 
 	public record Create(
+		Long userId,
 		String name,
 		Long parentFolderId) {
 	}
 
 	public record Read(
+		Long userId,
 		Long folderId) {
 	}
 
 	public record Update(
+		Long userId,
 		Long folderId,
 		String name
 	) {
 	}
 
 	public record Move(
+		Long userId,
 		Long folderId,
 		Long parentFolderId,
 		int orderIdx
@@ -25,6 +29,7 @@ public class FolderCommand {
 	}
 
 	public record Delete(
+		Long userId,
 		Long folderId
 	) {
 	}

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/dto/FolderCommand.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/dto/FolderCommand.java
@@ -1,5 +1,7 @@
 package kernel360.techpick.feature.domain.folder.dto;
 
+import java.util.List;
+
 public class FolderCommand {
 
 	public record Create(
@@ -22,15 +24,15 @@ public class FolderCommand {
 
 	public record Move(
 		Long userId,
-		Long folderId,
-		Long parentFolderId,
+		List<Long> folderIdList,
+		Long destinationFolderId,
 		int orderIdx
 	) {
 	}
 
 	public record Delete(
 		Long userId,
-		Long folderId
+		List<Long> folderIdList
 	) {
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/exception/ApiFolderErrorCode.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/exception/ApiFolderErrorCode.java
@@ -24,8 +24,8 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 		("F0-005", HttpStatus.NOT_IMPLEMENTED, "미구현 폴더 타입에 대한 서비스 요청", ErrorLevel.MUST_NEVER_HAPPEN()),
 	BASIC_FOLDER_ALREADY_EXISTS
 		("F0-006", HttpStatus.NOT_ACCEPTABLE, "기본 폴더는 1개만 존재할 수 있음.", ErrorLevel.MUST_NEVER_HAPPEN()),
-	INVALID_MOVE_OPERATION
-		("F0-007", HttpStatus.NOT_ACCEPTABLE, "잘못된 이동 행위", ErrorLevel.SHOULD_NOT_HAPPEN()),
+	INVALID_MOVE_TARGET
+		("F0-007", HttpStatus.NOT_ACCEPTABLE, "이동하려는 폴더들의 범위가 올바르지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	;
 
 	private final String code;

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/exception/ApiFolderException.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/exception/ApiFolderException.java
@@ -40,7 +40,7 @@ public class ApiFolderException extends ApiException {
 		return new ApiFolderException(ApiFolderErrorCode.BASIC_FOLDER_ALREADY_EXISTS);
 	}
 
-	public static ApiFolderException INVALID_PICK_MOVE_OPERATION() {
-		return new ApiFolderException(ApiFolderErrorCode.INVALID_MOVE_OPERATION);
+	public static ApiFolderException INVALID_MOVE_TARGET() {
+		return new ApiFolderException(ApiFolderErrorCode.INVALID_MOVE_TARGET);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderService.java
@@ -9,13 +9,13 @@ public interface FolderService {
 
 	FolderResult getFolder(FolderCommand.Read command);
 
-	List<FolderResult> getFolderListByParentFolderId(FolderCommand.Read command);
+	List<FolderResult> getChildFolderList(FolderCommand.Read command);
 
-	FolderResult saveNewFolder(FolderCommand.Create command);
+	FolderResult saveFolder(FolderCommand.Create command);
 
 	FolderResult updateFolder(FolderCommand.Update command);
 
-	FolderResult moveFolder(FolderCommand.Move command);
+	void moveFolder(FolderCommand.Move command);
 
 	void deleteFolder(FolderCommand.Delete command);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderService.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderService.java
@@ -11,6 +11,12 @@ public interface FolderService {
 
 	List<FolderResult> getChildFolderList(FolderCommand.Read command);
 
+	FolderResult getRootFolder(Long userId);
+
+	FolderResult getRecycleBin(Long userId);
+
+	FolderResult getUnclassifiedFolder(Long userId);
+
 	FolderResult saveFolder(FolderCommand.Create command);
 
 	FolderResult updateFolder(FolderCommand.Update command);

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
@@ -48,6 +48,24 @@ public class FolderServiceImpl implements FolderService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
+	public FolderResult getRootFolder(Long userId) {
+		return folderMapper.toResult(folderAdaptor.getRootFolder(userId));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public FolderResult getRecycleBin(Long userId) {
+		return folderMapper.toResult(folderAdaptor.getRecycleBin(userId));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public FolderResult getUnclassifiedFolder(Long userId) {
+		return folderMapper.toResult(folderAdaptor.getUnclassifiedFolder(userId));
+	}
+
+	@Override
 	@Transactional
 	public FolderResult saveFolder(FolderCommand.Create command) {
 		return folderMapper.toResult(folderAdaptor.saveFolder(command));

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
@@ -10,20 +10,20 @@ import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
 import kernel360.techpick.feature.domain.folder.dto.FolderMapper;
 import kernel360.techpick.feature.domain.folder.dto.FolderResult;
 import kernel360.techpick.feature.domain.folder.exception.ApiFolderException;
-import kernel360.techpick.feature.infrastructure.folder.FolderAdapter;
+import kernel360.techpick.feature.infrastructure.folder.FolderAdaptor;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class FolderServiceImpl implements FolderService {
 
-	private final FolderAdapter folderAdapter;
+	private final FolderAdaptor folderAdaptor;
 	private final FolderMapper folderMapper;
 
 	@Override
 	@Transactional(readOnly = true)
 	public FolderResult getFolder(FolderCommand.Read command) {
-		Folder folder = folderAdapter.getFolder(command.folderId());
+		Folder folder = folderAdaptor.getFolder(command.folderId());
 
 		if (!command.userId().equals(folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
@@ -35,13 +35,13 @@ public class FolderServiceImpl implements FolderService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<FolderResult> getChildFolderList(FolderCommand.Read command) {
-		Folder folder = folderAdapter.getFolder(command.folderId());
+		Folder folder = folderAdaptor.getFolder(command.folderId());
 
 		if (!command.userId().equals(folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 
-		return folderAdapter.getFolderList(folder.getChildFolderOrderList())
+		return folderAdaptor.getFolderList(folder.getChildFolderOrderList())
 			.stream()
 			.map(folderMapper::toResult)
 			.toList();
@@ -50,36 +50,36 @@ public class FolderServiceImpl implements FolderService {
 	@Override
 	@Transactional
 	public FolderResult saveFolder(FolderCommand.Create command) {
-		return folderMapper.toResult(folderAdapter.saveFolder(command));
+		return folderMapper.toResult(folderAdaptor.saveFolder(command));
 	}
 
 	@Override
 	@Transactional
 	public FolderResult updateFolder(FolderCommand.Update command) {
 
-		Folder folder = folderAdapter.getFolder(command.folderId());
+		Folder folder = folderAdaptor.getFolder(command.folderId());
 
 		if (!command.userId().equals(folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 
-		return folderMapper.toResult(folderAdapter.updateFolder(command));
+		return folderMapper.toResult(folderAdaptor.updateFolder(command));
 	}
 
 	@Override
 	@Transactional
 	public void moveFolder(FolderCommand.Move command) {
 
-		Folder folder = folderAdapter.getFolder(command.folderId());
+		Folder folder = folderAdaptor.getFolder(command.folderId());
 
 		if (!command.userId().equals(folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 
 		if (isParentFolderNotChanged(command, folder.getParentFolder())) {
-			folderAdapter.moveFolderWithinParent(command);
+			folderAdaptor.moveFolderWithinParent(command);
 		} else {
-			folderAdapter.moveFolderToDifferentParent(command);
+			folderAdaptor.moveFolderToDifferentParent(command);
 		}
 	}
 
@@ -87,13 +87,13 @@ public class FolderServiceImpl implements FolderService {
 	@Transactional
 	public void deleteFolder(FolderCommand.Delete command) {
 
-		Folder folder = folderAdapter.getFolder(command.folderId());
+		Folder folder = folderAdaptor.getFolder(command.folderId());
 
 		if (!command.userId().equals(folder.getUser().getId())) {
 			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 
-		folderAdapter.deleteFolder(command);
+		folderAdaptor.deleteFolder(command);
 	}
 
 	private boolean isParentFolderNotChanged(FolderCommand.Move command, Folder originalFolder) {

--- a/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/folder/service/FolderServiceImpl.java
@@ -6,12 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kernel360.techpick.core.model.folder.Folder;
-import kernel360.techpick.core.model.user.User;
 import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
 import kernel360.techpick.feature.domain.folder.dto.FolderMapper;
 import kernel360.techpick.feature.domain.folder.dto.FolderResult;
+import kernel360.techpick.feature.domain.folder.exception.ApiFolderException;
 import kernel360.techpick.feature.infrastructure.folder.FolderAdapter;
-import kernel360.techpick.feature.infrastructure.user.reader.UserReader;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,23 +19,29 @@ public class FolderServiceImpl implements FolderService {
 
 	private final FolderAdapter folderAdapter;
 	private final FolderMapper folderMapper;
-	private final UserReader userReader;
 
 	@Override
 	@Transactional(readOnly = true)
 	public FolderResult getFolder(FolderCommand.Read command) {
-		User user = userReader.readCurrentUser();
-		return folderMapper.toResult(folderAdapter.readFolder(user, command.folderId()));
+		Folder folder = folderAdapter.getFolder(command.folderId());
+
+		if (!command.userId().equals(folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+
+		return folderMapper.toResult(folder);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<FolderResult> getFolderListByParentFolderId(FolderCommand.Read command) {
+	public List<FolderResult> getChildFolderList(FolderCommand.Read command) {
+		Folder folder = folderAdapter.getFolder(command.folderId());
 
-		User user = userReader.readCurrentUser();
-		Folder parentFolder = folderAdapter.readFolder(user, command.folderId());
+		if (!command.userId().equals(folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
 
-		return folderAdapter.readFolderList(user, parentFolder)
+		return folderAdapter.getFolderList(folder.getChildFolderOrderList())
 			.stream()
 			.map(folderMapper::toResult)
 			.toList();
@@ -44,53 +49,51 @@ public class FolderServiceImpl implements FolderService {
 
 	@Override
 	@Transactional
-	public FolderResult saveNewFolder(FolderCommand.Create command) {
-
-		User user = userReader.readCurrentUser();
-		Folder parentFolder = folderAdapter.readFolder(user, command.parentFolderId());
-		Folder folder = folderMapper.toEntity(command, user, parentFolder);
-
-		return folderMapper.toResult(folderAdapter.writeFolder(folder));
+	public FolderResult saveFolder(FolderCommand.Create command) {
+		return folderMapper.toResult(folderAdapter.saveFolder(command));
 	}
 
 	@Override
 	@Transactional
 	public FolderResult updateFolder(FolderCommand.Update command) {
 
-		User user = userReader.readCurrentUser();
-		Folder targetFolder = folderAdapter.readFolder(user, command.folderId());
-		targetFolder.updateFolderName(command.name());
+		Folder folder = folderAdapter.getFolder(command.folderId());
 
-		return folderMapper.toResult(targetFolder);
+		if (!command.userId().equals(folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+
+		return folderMapper.toResult(folderAdapter.updateFolder(command));
 	}
 
 	@Override
 	@Transactional
-	public FolderResult moveFolder(FolderCommand.Move command) {
-		User user = userReader.readCurrentUser();
-		Folder targetFolder = folderAdapter.readFolder(user, command.folderId());
-		Folder originalParentFolder = targetFolder.getParentFolder();
+	public void moveFolder(FolderCommand.Move command) {
 
-		if (isParentFolderNotChanged(command, originalParentFolder)) {
-			originalParentFolder.updateChildFolderOrder(command.folderId(), command.orderIdx());
-			return folderMapper.toResult(targetFolder);
+		Folder folder = folderAdapter.getFolder(command.folderId());
+
+		if (!command.userId().equals(folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
 		}
 
-		originalParentFolder.removeChildFolderOrder(command.folderId());
-		Folder newParentFolder = folderAdapter.readFolder(user, command.parentFolderId());
-		newParentFolder.updateChildFolderOrder(command.folderId(), command.orderIdx());
-		targetFolder.updateParentFolder(newParentFolder);
-
-		return folderMapper.toResult(targetFolder);
+		if (isParentFolderNotChanged(command, folder.getParentFolder())) {
+			folderAdapter.moveFolderWithinParent(command);
+		} else {
+			folderAdapter.moveFolderToDifferentParent(command);
+		}
 	}
 
 	@Override
 	@Transactional
 	public void deleteFolder(FolderCommand.Delete command) {
-		User user = userReader.readCurrentUser();
-		Folder targetFolder = folderAdapter.readFolder(user, command.folderId());
-		targetFolder.getParentFolder().removeChildFolderOrder(command.folderId());
-		folderAdapter.removeFolder(targetFolder);
+
+		Folder folder = folderAdapter.getFolder(command.folderId());
+
+		if (!command.userId().equals(folder.getUser().getId())) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+
+		folderAdapter.deleteFolder(command);
 	}
 
 	private boolean isParentFolderNotChanged(FolderCommand.Move command, Folder originalFolder) {

--- a/backend/src/main/java/kernel360/techpick/feature/domain/pick/service/PickServiceImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/domain/pick/service/PickServiceImpl.java
@@ -11,7 +11,7 @@ import kernel360.techpick.core.model.pick.Pick;
 import kernel360.techpick.feature.domain.pick.dto.PickCommand;
 import kernel360.techpick.feature.domain.pick.dto.PickMapper;
 import kernel360.techpick.feature.domain.pick.dto.PickResult;
-import kernel360.techpick.feature.infrastructure.folder.FolderAdapter;
+import kernel360.techpick.feature.infrastructure.folder.FolderAdaptor;
 import kernel360.techpick.feature.infrastructure.link.writer.LinkWriter;
 import kernel360.techpick.feature.infrastructure.pick.PickAdaptor;
 import kernel360.techpick.feature.infrastructure.user.reader.UserReader;
@@ -24,7 +24,7 @@ public class PickServiceImpl implements PickService {
 	private final LinkWriter linkWriter;
 	private final PickAdaptor pickAdaptor;
 	private final PickMapper pickMapper;
-	private final FolderAdapter folderAdapter;
+	private final FolderAdaptor folderAdaptor;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -38,7 +38,7 @@ public class PickServiceImpl implements PickService {
 	@Transactional
 	public PickResult saveNewPick(PickCommand.Create command) {
 		var user = userReader.readUser(command.userId());
-		var folder = folderAdapter.readFolder(user, command.parentFolderId());
+		var folder = folderAdaptor.getFolder(command.parentFolderId());
 		var link = linkWriter.writeLink(command.linkInfo());
 		var pick = pickAdaptor.savePick(pickMapper.toEntity(command, user, folder, link));
 		return pickMapper.toCreateResult(pick);
@@ -49,7 +49,7 @@ public class PickServiceImpl implements PickService {
 	public PickResult updatePick(PickCommand.Update command) {
 		var user = userReader.readUser(command.userId());
 		var pick = pickAdaptor.getPick(user, command.pickId())
-							  .updateTitle(command.title()).updateMemo(command.memo());
+			.updateTitle(command.title()).updateMemo(command.memo());
 		updateNewTagIdList(pick, command.tagIdList());
 		return pickMapper.toUpdateResult(pick);
 	}
@@ -59,7 +59,7 @@ public class PickServiceImpl implements PickService {
 	public PickResult movePick(PickCommand.Move command) {
 		var user = userReader.readUser(command.userId());
 		var pick = pickAdaptor.getPick(user, command.pickId());
-		var destinationFolder = folderAdapter.readFolder(user, command.parentFolderId());
+		var destinationFolder = folderAdaptor.getFolder(command.parentFolderId());
 
 		if (isParentFolderChanged(pick.getParentFolder(), destinationFolder)) {
 			movePickToOtherFolder(pick, destinationFolder, command.orderIdx());

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdapter.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdapter.java
@@ -3,16 +3,21 @@ package kernel360.techpick.feature.infrastructure.folder;
 import java.util.List;
 
 import kernel360.techpick.core.model.folder.Folder;
-import kernel360.techpick.core.model.user.User;
-import kernel360.techpick.feature.domain.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
 
 public interface FolderAdapter {
 
-	Folder readFolder(User user, Long folderId);
+	Folder getFolder(Long folderId);
 
-	List<Folder> readFolderList(User user, Folder parentFolder);
+	List<Folder> getFolderList(List<Long> idList);
 
-	Folder writeFolder(Folder folder) throws ApiFolderException;
+	Folder saveFolder(FolderCommand.Create command);
 
-	void removeFolder(Folder folder);
+	Folder updateFolder(FolderCommand.Update command);
+
+	List<Long> moveFolderWithinParent(FolderCommand.Move command);
+
+	List<Long> moveFolderToDifferentParent(FolderCommand.Move command);
+	
+	void deleteFolder(FolderCommand.Delete command);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdapterImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdapterImpl.java
@@ -2,45 +2,98 @@ package kernel360.techpick.feature.infrastructure.folder;
 
 import java.util.List;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.core.model.folder.FolderRepository;
 import kernel360.techpick.core.model.user.User;
+import kernel360.techpick.core.model.user.UserRepository;
+import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
+import kernel360.techpick.feature.domain.folder.dto.FolderMapper;
 import kernel360.techpick.feature.domain.folder.exception.ApiFolderException;
+import kernel360.techpick.feature.domain.user.exception.ApiUserException;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class FolderAdapterImpl implements FolderAdapter {
 
-	FolderRepository folderRepository;
+	private final FolderRepository folderRepository;
+	private final UserRepository userRepository;
+	private final FolderMapper folderMapper;
 
 	@Override
-	public Folder readFolder(User user, Long folderId) {
-		Folder folder = folderRepository.findById(folderId).orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		if (ObjectUtils.notEqual(folder.getUser(), user)) {
-			throw ApiFolderException.FOLDER_ACCESS_DENIED();
-		}
+	@Transactional(readOnly = true)
+	public Folder getFolder(Long folderId) {
+		return folderRepository.findById(folderId).orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<Folder> getFolderList(List<Long> idList) {
+		return folderRepository.findAllByIdListOrdered(idList);
+	}
+
+	@Override
+	@Transactional
+	public Folder saveFolder(FolderCommand.Create command) {
+		User user = userRepository.findById(command.userId()).orElseThrow(ApiUserException::USER_NOT_FOUND);
+		Folder parentFolder = folderRepository.findById(command.parentFolderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+
+		return folderRepository.save(folderMapper.toEntity(command, user, parentFolder));
+	}
+
+	@Override
+	@Transactional
+	public Folder updateFolder(FolderCommand.Update command) {
+		Folder folder = folderRepository.findById(command.folderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+		folder.updateFolderName(command.name());
+
 		return folder;
 	}
 
 	@Override
-	public List<Folder> readFolderList(User user, Folder parentFolder) {
-		if (ObjectUtils.notEqual(parentFolder.getUser(), user)) {
-			throw ApiFolderException.FOLDER_ACCESS_DENIED();
-		}
-		return folderRepository.findByParentFolder(parentFolder);
+	@Transactional
+	public List<Long> moveFolderWithinParent(FolderCommand.Move command) {
+		Folder parentFolder = folderRepository.findById(command.parentFolderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+
+		parentFolder.getChildFolderOrderList().remove(command.folderId());
+		parentFolder.getChildFolderOrderList().add(command.orderIdx(), command.folderId());
+
+		return parentFolder.getChildFolderOrderList();
 	}
 
 	@Override
-	public Folder writeFolder(Folder folder) throws ApiFolderException {
-		return folderRepository.save(folder);
+	@Transactional
+	public List<Long> moveFolderToDifferentParent(FolderCommand.Move command) {
+		Folder folder = folderRepository.findById(command.folderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+
+		Folder oldParent = folder.getParentFolder();
+		oldParent.getChildFolderOrderList().remove(command.folderId());
+
+		Folder newParent = folderRepository.findById(command.parentFolderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+		newParent.getChildFolderOrderList().add(command.orderIdx(), command.folderId());
+
+		folder.updateParentFolder(newParent);
+
+		return newParent.getChildFolderOrderList();
 	}
 
 	@Override
-	public void removeFolder(Folder folder) {
+	@Transactional
+	public void deleteFolder(FolderCommand.Delete command) {
+		Folder folder = folderRepository.findById(command.folderId())
+			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+
+		Folder parentFolder = folder.getParentFolder();
+		parentFolder.getChildFolderOrderList().remove(folder.getId());
+
 		folderRepository.delete(folder);
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
@@ -11,6 +11,12 @@ public interface FolderAdaptor {
 
 	List<Folder> getFolderList(List<Long> idList);
 
+	Folder getRootFolder(Long userId);
+
+	Folder getRecycleBin(Long userId);
+
+	Folder getUnclassifiedFolder(Long userId);
+
 	Folder saveFolder(FolderCommand.Create command);
 
 	Folder updateFolder(FolderCommand.Update command);

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
@@ -5,7 +5,7 @@ import java.util.List;
 import kernel360.techpick.core.model.folder.Folder;
 import kernel360.techpick.feature.domain.folder.dto.FolderCommand;
 
-public interface FolderAdapter {
+public interface FolderAdaptor {
 
 	Folder getFolder(Long folderId);
 
@@ -18,6 +18,6 @@ public interface FolderAdapter {
 	List<Long> moveFolderWithinParent(FolderCommand.Move command);
 
 	List<Long> moveFolderToDifferentParent(FolderCommand.Move command);
-	
+
 	void deleteFolder(FolderCommand.Delete command);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptor.java
@@ -9,7 +9,11 @@ public interface FolderAdaptor {
 
 	Folder getFolder(Long folderId);
 
+	// idList에 포함된 모든 ID에 해당하는 폴더 리스트 조회, 순서를 보장하지 않음
 	List<Folder> getFolderList(List<Long> idList);
+
+	// idList에 포함된 모든 ID에 해당하는 폴더 리스트 조회, 순서는 idList의 순서를 따름
+	List<Folder> getFolderListPreservingOrder(List<Long> idList);
 
 	Folder getRootFolder(Long userId);
 
@@ -25,5 +29,5 @@ public interface FolderAdaptor {
 
 	List<Long> moveFolderToDifferentParent(FolderCommand.Move command);
 
-	void deleteFolder(FolderCommand.Delete command);
+	void deleteFolderList(FolderCommand.Delete command);
 }

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptorImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptorImpl.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class FolderAdapterImpl implements FolderAdapter {
+public class FolderAdaptorImpl implements FolderAdaptor {
 
 	private final FolderRepository folderRepository;
 	private final UserRepository userRepository;

--- a/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptorImpl.java
+++ b/backend/src/main/java/kernel360/techpick/feature/infrastructure/folder/FolderAdaptorImpl.java
@@ -36,6 +36,24 @@ public class FolderAdaptorImpl implements FolderAdaptor {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
+	public Folder getRootFolder(Long userId) {
+		return folderRepository.findRootByUserId(userId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Folder getRecycleBin(Long userId) {
+		return folderRepository.findRecycleBinByUserId(userId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Folder getUnclassifiedFolder(Long userId) {
+		return folderRepository.findUnclassifiedByUserId(userId);
+	}
+
+	@Override
 	@Transactional
 	public Folder saveFolder(FolderCommand.Create command) {
 		User user = userRepository.findById(command.userId()).orElseThrow(ApiUserException::USER_NOT_FOUND);


### PR DESCRIPTION
- Close #315

## What is this PR? 🔍

- 기능 : Folder 도메인 리팩토링
- issue : #315

## Changes 📝
- FolderFacade 제거

- FolderService가 Folder에 대한 모든 비즈니스 로직을 가지도록 리팩토링
  - 사용자 검증과 같은 비즈니스 로직적인 검증도 Service에서 처리하도록 함

- FolderAdaptor는 엔티티 변경을 db에 반영하는 책임만 가지도록 리팩토링

- 기본폴더 조회 메소드 추가
  - `FolderResult getRootFolder(Long userId)`
  - `FolderResult getRecycleBin(Long userId)`
  - `FolderResult getUnclassifiedFolder(Long userId)`

- idList로 조회 시 순서 보장하는 조회와 보장하지 않는 조회 메소드 분리
  - `List<Folder> getFolderList(List<Long> idList)`
  - `List<Folder> getFolderListPreservingOrder(List<Long> idList)`

## Precaution

### "PickServiceImpl에 수정"이 있으므로 리팩토링시 유의

@sangwonsheep 
Pick 구현 시에도 idList를 받아서 idList 순서를 유지한 PickList를 반환하는 메소드가 필요할것으로 예상됨