### PR TITLE
[FEAT] LoginUserId 커스텀 어노테이션 구현

### DIFF
--- a/backend/src/main/java/kernel360/techpick/core/annotation/LoginUserId.java
+++ b/backend/src/main/java/kernel360/techpick/core/annotation/LoginUserId.java
@@ -1,0 +1,11 @@
+package kernel360.techpick.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}

--- a/backend/src/main/java/kernel360/techpick/core/config/WebConfig.java
+++ b/backend/src/main/java/kernel360/techpick/core/config/WebConfig.java
@@ -1,0 +1,18 @@
+package kernel360.techpick.core.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kernel360.techpick.core.util.LoginUserArgumentResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new LoginUserArgumentResolver());
+	}
+}

--- a/backend/src/main/java/kernel360/techpick/core/util/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/kernel360/techpick/core/util/LoginUserArgumentResolver.java
@@ -1,0 +1,33 @@
+package kernel360.techpick.core.util;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kernel360.techpick.core.annotation.LoginUserId;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(LoginUserId.class) &&
+			Long.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		var authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal() instanceof Long) {
+			return authentication.getPrincipal();
+		}
+		throw new IllegalArgumentException("잘못된 인증정보");
+	}
+}


### PR DESCRIPTION
- Close #325

## What is this PR? 🔍

- 기능 : LoginUserId 커스텀 어노테이션 구현
- issue : #325

## Changes 📝

V1의 컨트롤러에서 Authentication을 주입받아 Principal을 Long타입으로 캐스팅해 userId를 얻는 과정은 매우 불편
이를 커스텀 어노테이션으로 해결함

### `@LoginUserId`
- Long 타입 파라미터에 붙이면 현재 사용자의 인증정보(id)를 주입해줌

## Precaution

추후 인증 방식이 userId를 직접 SecurityContext에 넣는 방식이 아니게 된다면 리팩토링 필요