### PR TITLE
[FEAT] Tag API 구현 및 Swagger 명세

### DIFF
--- a/backend/src/main/java/kernel360/techpick/feature/api/tag/controller/TagApiController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/tag/controller/TagApiController.java
@@ -76,7 +76,7 @@ public class TagApiController implements TagApiSpecification {
 	@Operation(summary = "태그 이동", description = "사용자가 등록한 태그의 순서를 변경합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "태그 이동 성공"),
-		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
+		@ApiResponse(responseCode = "401", description = "본인 태그만 이동할 수 있습니다.")
 	})
 	public ResponseEntity<Void> moveTag(Long userId, TagApiRequest.Move request) {
 		tagService.moveUserTag(tagApiMapper.toMoveCommand(userId, request));
@@ -87,7 +87,7 @@ public class TagApiController implements TagApiSpecification {
 	@Operation(summary = "태그 삭제", description = "사용자가 등록한 태그를 삭제합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "태그 삭제 성공"),
-		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
+		@ApiResponse(responseCode = "401", description = "본인 태그만 삭제할 수 있습니다.")
 	})
 	public ResponseEntity<Void> deleteTag(Long userId, TagApiRequest.Delete request) {
 		tagService.deleteTag(tagApiMapper.toDeleteCommand(userId, request));

--- a/backend/src/main/java/kernel360/techpick/feature/api/tag/controller/TagApiController.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/tag/controller/TagApiController.java
@@ -1,12 +1,96 @@
 package kernel360.techpick.feature.api.tag.controller;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kernel360.techpick.feature.api.tag.dto.TagApiMapper;
+import kernel360.techpick.feature.api.tag.dto.TagApiRequest;
+import kernel360.techpick.feature.api.tag.dto.TagApiResponse;
+import kernel360.techpick.feature.domain.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/tags")
+@Tag(name = "Tag API", description = "태그 API")
 public class TagApiController implements TagApiSpecification {
+
+	private final TagService tagService;
+	private final TagApiMapper tagApiMapper;
+
+	@GetMapping
+	@Operation(summary = "태그 조회", description = "사용자가 등록한 전체 태그를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공",
+			content = @Content(schema = @Schema(implementation = TagApiResponse.Read.class))
+		)
+	})
+	public ResponseEntity<List<TagApiResponse.Read>> getAllUserTag(Long userId) {
+		return ResponseEntity.ok(
+			tagService.getUserTagList(userId).stream()
+				.map(tagApiMapper::toReadResponse)
+				.toList()
+		);
+	}
+
+	@PostMapping
+	@Operation(summary = "태그 추가", description = "새로운 태그를 추가합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "태그 추가 성공",
+			content = @Content(schema = @Schema(implementation = TagApiResponse.Create.class))
+		),
+		@ApiResponse(responseCode = "400", description = "중복된 태그 이름", content = @Content(schema = @Schema()))
+	})
+	public ResponseEntity<TagApiResponse.Create> createTag(Long userId, TagApiRequest.Create request) {
+		return ResponseEntity.ok(
+			tagApiMapper.toCreateResponse(tagService.saveTag(tagApiMapper.toCreateCommand(userId, request))));
+	}
+
+	@PutMapping
+	@Operation(summary = "태그 수정", description = "사용자가 등록한 태그를 수정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "태그 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "중복된 태그 이름"),
+		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
+	})
+	public ResponseEntity<Void> updateTag(Long userId, TagApiRequest.Update request) {
+		tagService.updateTag(tagApiMapper.toUpdateCommand(userId, request));
+		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping
+	@Operation(summary = "태그 이동", description = "사용자가 등록한 태그의 순서를 변경합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "태그 이동 성공"),
+		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
+	})
+	public ResponseEntity<Void> moveTag(Long userId, TagApiRequest.Move request) {
+		tagService.moveUserTag(tagApiMapper.toMoveCommand(userId, request));
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping
+	@Operation(summary = "태그 삭제", description = "사용자가 등록한 태그를 삭제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "태그 삭제 성공"),
+		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
+	})
+	public ResponseEntity<Void> deleteTag(Long userId, TagApiRequest.Delete request) {
+		tagService.deleteTag(tagApiMapper.toDeleteCommand(userId, request));
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiMapper.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiMapper.java
@@ -14,13 +14,15 @@ import kernel360.techpick.feature.domain.tag.dto.TagResult;
 )
 public interface TagApiMapper {
 
-	TagCommand.Read toReadCommand(TagApiRequest.Read request, Long userId);
+	TagCommand.Read toReadCommand(Long userId, TagApiRequest.Read request);
 
-	TagCommand.Create toCreateCommand(TagApiRequest.Create request, Long userId);
+	TagCommand.Create toCreateCommand(Long userId, TagApiRequest.Create request);
 
-	TagCommand.Update toUpdateCommand(TagApiRequest.Update request, Long userId);
+	TagCommand.Update toUpdateCommand(Long userId, TagApiRequest.Update request);
 
-	TagCommand.Delete toDeleteCommand(TagApiRequest.Delete request, Long userId);
+	TagCommand.Move toMoveCommand(Long userId, TagApiRequest.Move request);
+
+	TagCommand.Delete toDeleteCommand(Long userId, TagApiRequest.Delete request);
 
 	TagApiResponse.Read toReadResponse(TagResult result);
 

--- a/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiRequest.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiRequest.java
@@ -1,5 +1,6 @@
 package kernel360.techpick.feature.api.tag.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -7,21 +8,28 @@ import jakarta.validation.constraints.NotNull;
 public class TagApiRequest {
 
 	public record Create(
-		@NotBlank String name,
-		@NotNull Integer colorNumber) {
+		@Schema(example = "SpringBoot") @NotBlank String name,
+		@Schema(example = "12") @NotNull Integer colorNumber) {
 	}
 
 	public record Read(
-		@NotNull Long tagId) {
+		@Schema(example = "2") @NotNull Long tagId) {
 	}
 
 	public record Update(
-		@NotNull Long tagId,
-		@NotEmpty String name,
-		@NotNull Integer colorNumber) {
+		@Schema(example = "2") @NotNull Long tagId,
+		@Schema(example = "new tag name") @NotEmpty String name,
+		@Schema(example = "7") @NotNull Integer colorNumber) {
+	}
+
+	public record Move(
+		@Schema(example = "3") @NotNull Long tagId,
+		@Schema(example = "1") @NotNull int orderIdx
+	) {
 	}
 
 	public record Delete(
-		@NotNull Long tagId) {
+		@Schema(example = "4") @NotNull Long tagId
+	) {
 	}
 }

--- a/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiResponse.java
+++ b/backend/src/main/java/kernel360/techpick/feature/api/tag/dto/TagApiResponse.java
@@ -5,21 +5,21 @@ public class TagApiResponse {
 	public record Create(
 		Long id,
 		String name,
-		String colorNumber
+		Integer colorNumber
 	) {
 	}
 
 	public record Read(
 		Long id,
 		String name,
-		String colorNumber
+		Integer colorNumber
 	) {
 	}
 
 	public record Update(
 		Long id,
 		String name,
-		String colorNumber
+		Integer colorNumber
 	) {
 	}
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -39,6 +39,9 @@ springdoc:
   api-docs:
     path: /api-docs
   show-actuator: true
+  # swagger 가 패키지를 포함하여 관리하게 함 -> 같은 클래스내의 inner class 또한 구분 가능
+  # ex) TagApiResponse.Create TagApiResponse.Move 를 구분할 수 있음
+  use-fqn: true
 
 api:
   base-url: ${TECHPICK_BASE_URL}


### PR DESCRIPTION
- Close #324

## What is this PR? 🔍

- 기능 : Tag API 구현 및 Swagger 명세
- issue : #324

## Changes 📝

### Tag API 구현
- `ResponseEntity<List<TagApiResponse.Read>> getAllUserTag(Long userId)`
- `ResponseEntity<TagApiResponse.Create> createTag(Long userId, TagApiRequest.Create request)`
- `ResponseEntity<Void> updateTag(Long userId, TagApiRequest.Update request)`
- `ResponseEntity<Void> moveTag(Long userId, TagApiRequest.Move request)`
- `ResponseEntity<Void> deleteTag(Long userId, TagApiRequest.Delete request)`

### Swagger 명세 추가
- API 설명
- 요청 예시
- 응답 형식 및 response code
