### PR TITLE
[REFACTOR] local-dev-prod 설정 분리

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -39,10 +39,11 @@ services:
     env_file:
       - .env
     environment:
-      - DOCKER_MYSQL_URL=jdbc:mysql://techpick-mysql/TECHPICK_DB?createDatabaseIfNotExist=true
+      - DOCKER_MYSQL_URL=${DOCKER_MYSQL_URL}
       - DOCKER_MYSQL_USERNAME=${DOCKER_MYSQL_USERNAME}
       - DOCKER_MYSQL_PASSWORD=${DOCKER_MYSQL_PASSWORD}
       - TZ=Asia/Seoul
+      - SPRING_PROFILES_ACTIVE=local
     networks:
       - techpick-network
     depends_on:
@@ -53,15 +54,14 @@ services:
       context: ./techpick-batch
       dockerfile: Dockerfile
     container_name: techpick-batch
-    ports:
-      - "8081:8080"
     env_file:
       - .env
     environment:
-      - DOCKER_MYSQL_URL=jdbc:mysql://techpick-mysql/TECHPICK_DB?createDatabaseIfNotExist=true
+      - DOCKER_MYSQL_URL=${DOCKER_MYSQL_URL}
       - DOCKER_MYSQL_USERNAME=${DOCKER_MYSQL_USERNAME}
       - DOCKER_MYSQL_PASSWORD=${DOCKER_MYSQL_PASSWORD}
       - TZ=Asia/Seoul
+      - SPRING_PROFILES_ACTIVE=local
     networks:
       - techpick-network
     depends_on:

--- a/backend/techpick-api/src/main/java/techpick/api/config/SwaggerConfig.java
+++ b/backend/techpick-api/src/main/java/techpick/api/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.models.servers.Server;
 @Configuration
 public class SwaggerConfig {
 
-	@Value("${api.base-url}")
+	@Value("${core.base-url}")
 	private String baseUrl;
 
 	@Bean

--- a/backend/techpick-core/src/main/resources/application-core.yaml
+++ b/backend/techpick-core/src/main/resources/application-core.yaml
@@ -11,12 +11,9 @@ spring:
   jpa:
     properties:
       hibernate:
-        format_sql: false
-        show_sql: false
         dialect: org.hibernate.dialect.MySQL8Dialect
-    hibernate:
-      ddl-auto: update # 이 부분 설정 주의 필요
     open-in-view: false
+
   datasource:
     url: ${DOCKER_MYSQL_URL}
     username: ${DOCKER_MYSQL_USERNAME}
@@ -33,6 +30,13 @@ spring:
   config:
     activate:
       on-profile: local
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: true
+    hibernate:
+      ddl-auto: create
 core:
   base-url: http://localhost:8080
 
@@ -42,6 +46,13 @@ spring:
   config:
     activate:
       on-profile: dev
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+    hibernate:
+      ddl-auto: update
 core:
   base-url: https://api.minlife.me
 
@@ -51,6 +62,13 @@ spring:
   config:
     activate:
       on-profile: prod
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+    hibernate:
+      ddl-auto: none
 core:
   base-url: https://api.techpick.org
 

--- a/backend/techpick-core/src/main/resources/application-core.yaml
+++ b/backend/techpick-core/src/main/resources/application-core.yaml
@@ -23,10 +23,35 @@ spring:
     password: ${DOCKER_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-api:
-  base-url: ${TECHPICK_BASE_URL}
-  cookie-domain: minlife.me
-
 #logging: # /* Transaction Logging */
 #  level:
 #    org.springframework.orm.jpa: DEBUG
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+core:
+  base-url: http://localhost:8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: dev
+core:
+  base-url: https://api.minlife.me
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+core:
+  base-url: https://api.techpick.org
+
+---

--- a/backend/techpick-security/src/main/java/techpick/security/config/SecurityConfig.java
+++ b/backend/techpick-security/src/main/java/techpick/security/config/SecurityConfig.java
@@ -35,8 +35,11 @@ public class SecurityConfig {
 	private final TechPickLogoutHandler techPickLogoutHandler;
 	private final TechPickAuthorizationRequestRepository requestRepository;
 
-	@Value("${api.base-url}")
+	@Value("${core.base-url}")
 	private String baseUrl;
+
+	@Value("${security.clientUrl}")
+	private String clientUrl;
 
 	public static final String ACCESS_TOKEN_KEY = "access_token";
 	public static final String LOGIN_FLAG_FOR_FRONTEND = "techPickLogin";
@@ -92,9 +95,7 @@ public class SecurityConfig {
 		config.setAllowCredentials(true);
 		config.setAllowedOrigins(List.of(
 			baseUrl,
-			// TODO: local - dev - prod 설정 분리하며 application.yaml로 옮길 예정
-			"https://local.minlife.me:3000",
-			"https://app.minlife.me"
+			clientUrl
 		));
 		config.addAllowedOriginPattern("chrome-extension://*");
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/backend/techpick-security/src/main/java/techpick/security/handler/OAuth2SuccessHandler.java
+++ b/backend/techpick-security/src/main/java/techpick/security/handler/OAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package techpick.security.handler;
 import java.io.IOException;
 import java.time.Duration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -27,8 +28,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final JwtUtil jwtUtil;
 	private final UserRepository userRepository;
 	private static final Duration ACCESS_TOKEN_DURATION = Duration.ofDays(1);
-	// TODO: 설정파일 리팩토링 진행하며 정리할 예정 일단 하드코딩
-	private static final String DEFAULT_REDIRECT_URL = "https://app.minlife.me";
+
+	@Value("${security.default-redirect-url}")
+	private String DEFAULT_REDIRECT_URL;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/backend/techpick-security/src/main/java/techpick/security/util/CookieUtil.java
+++ b/backend/techpick-security/src/main/java/techpick/security/util/CookieUtil.java
@@ -13,7 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class CookieUtil {
 
-	@Value("${api.cookie-domain}")
+	@Value("${security.cookie-domain}")
 	private String COOKIE_DOMAIN;
 
 	/**

--- a/backend/techpick-security/src/main/resources/application-security.yaml
+++ b/backend/techpick-security/src/main/resources/application-security.yaml
@@ -54,3 +54,38 @@ oauth2-attribute-config-provider:
     naver:
       name: "id"
       email: "email"
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+security:
+  clientUrl: https://local.minlife.me:3000
+  cookie-domain: localhost
+  default-redirect-url: http://localhost:8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: dev
+security:
+  clientUrl: https://app.minlife.me
+  cookie-domain: minlife.me
+  default-redirect-url: https://local.minlife.me
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+security:
+  clientUrl: https://app.techpick.org
+  cookie-domain: techpick.org
+  default-redirect-url: https://app.techpick.org
+
+---


### PR DESCRIPTION
- Close #378

## What is this PR? 🔍

- 기능 : local-dev-prod 설정 분리
- issue : #378

## Changes 📝

환경별 설정 분리
### local
`core.base-url: http://localhost:8080`
`security.clientUrl: https://local.minlife.me:3000`
`security.cookie-domain: localhost`
`security.default-redirect-url: http://localhost:8080`

### dev
`core.base-url: https://api.minlife.me`
`security.clientUrl: https://app.minlife.me`
`security.cookie-domain: minlife.me`
`security.default-redirect-url: https://local.minlife.me`

### prod
`core.base-url: https://api.techpick.org`
`security.clientUrl: https://app.techpick.org`
`security.cookie-domain: techpick.org`
`security.default-redirect-url: https://app.techpick.org`

---

## Precaution

docker-compose.yml 은 local 프로파일을 설정하도록 되어있으니 필요한 경우 수정

현재 application-core.yaml에서 mysql url이 docker network안에서 돌게 해놔서
intellij에서 실행하면 db 연결 안되고 docker-compose로 실행해야함
1. gradle build or jar bootJar 둘다 빌드
2. 도커 이미지 정리 : `docker image prune -af`
3. 도커 컴포즈 실행 : `docker-compose up --build -d`