### PR TITLE
[REFACTOR] Folder, Tag 리팩토링

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,8 +61,11 @@ subprojects {
         // map struct
         implementation 'org.mapstruct:mapstruct:1.5.3.Final'
         annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
-        
+
         implementation 'javax.xml.bind:jaxb-api:2.3.1' //xml 문서와 자바 객체 간 매핑을 자동화
+
+        // springdoc swagger dependency
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     }
 
     tasks.named('test') {

--- a/backend/techpick-api/build.gradle
+++ b/backend/techpick-api/build.gradle
@@ -12,8 +12,7 @@ repositories {
 dependencies {
     implementation project(":techpick-core")
     implementation project(":techpick-security")
-    // springdoc swagger dependency
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 }
 
 tasks.named('test') {

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import techpick.api.domain.folder.service.FolderService;
 import techpick.api.application.folder.dto.FolderApiMapper;
 import techpick.api.application.folder.dto.FolderApiRequest;
@@ -68,7 +70,7 @@ public class FolderApiController {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 조회할 수 있습니다.")
 	})
-	public ResponseEntity<List<FolderApiResponse>> getChildrenFolder(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<List<FolderApiResponse>> getChildrenFolder(@LoginUserId Long userId,
 		@PathVariable Long folderId) {
 		return ResponseEntity.ok(
 			folderService.getChildFolderList(mapper.toReadCommand(userId, folderId))
@@ -83,8 +85,8 @@ public class FolderApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "폴더 추가 성공")
 	})
-	public ResponseEntity<FolderApiResponse> createFolder(@Parameter(hidden = true) @LoginUserId Long userId,
-		FolderApiRequest.Create request) {
+	public ResponseEntity<FolderApiResponse> createFolder(@LoginUserId Long userId,
+		@Valid @RequestBody FolderApiRequest.Create request) {
 		return ResponseEntity.ok(
 			mapper.toApiResponse(folderService.saveFolder(mapper.toCreateCommand(userId, request)))
 		);
@@ -97,8 +99,8 @@ public class FolderApiController {
 		@ApiResponse(responseCode = "400", description = "기본 폴더는 수정할 수 없습니다."),
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 수정할 수 있습니다.")
 	})
-	public ResponseEntity<Void> updateFolder(@Parameter(hidden = true) @LoginUserId Long userId,
-		FolderApiRequest.Update request) {
+	public ResponseEntity<Void> updateFolder(@LoginUserId Long userId,
+		@Valid @RequestBody FolderApiRequest.Update request) {
 		folderService.updateFolder(mapper.toUpdateCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -111,8 +113,8 @@ public class FolderApiController {
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 이동할 수 있습니다."),
 		@ApiResponse(responseCode = "406", description = "부모가 다른 폴더들을 동시에 이동할 수 없습니다.")
 	})
-	public ResponseEntity<Void> moveFolder(@Parameter(hidden = true) @LoginUserId Long userId,
-		FolderApiRequest.Move request) {
+	public ResponseEntity<Void> moveFolder(@LoginUserId Long userId,
+		@Valid @RequestBody FolderApiRequest.Move request) {
 		folderService.moveFolder(mapper.toMoveCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -124,8 +126,8 @@ public class FolderApiController {
 		@ApiResponse(responseCode = "400", description = "기본 폴더는 삭제할 수 없습니다."),
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 삭제할 수 있습니다.")
 	})
-	public ResponseEntity<Void> deleteFolder(@Parameter(hidden = true) @LoginUserId Long userId,
-		FolderApiRequest.Delete request) {
+	public ResponseEntity<Void> deleteFolder(@LoginUserId Long userId,
+		@Valid @RequestBody FolderApiRequest.Delete request) {
 		folderService.deleteFolder(mapper.toDeleteCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -41,7 +41,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "200", description = "픽 리스트 조회 성공")
 	})
 	public ResponseEntity<PickApiResponse.Fetch> getFolderChildPickList(
-		@Parameter(hidden = true) @LoginUserId Long userId,
+		@LoginUserId Long userId,
 		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3") @RequestParam List<Long> folderIdList,
 		@Parameter(description = "검색 토큰 목록", example = "리액트, 쿼리, 서버") @RequestParam(required = false) List<String> searchTokenList) {
 
@@ -57,7 +57,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "200", description = "픽 여부 조회 성공"),
 		@ApiResponse(responseCode = "404", description = "해당 링크에 대해 픽이 되어 있지 않습니다.")
 	})
-	public ResponseEntity<PickApiResponse.Pick> getPickUrl(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Pick> getPickUrl(@LoginUserId Long userId,
 		@RequestParam String link) {
 		return ResponseEntity.ok(pickApiMapper.toApiResponse(pickService.getPickUrl(userId, link)));
 	}
@@ -67,7 +67,7 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 상세 조회 성공")
 	})
-	public ResponseEntity<PickApiResponse.Pick> getPick(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Pick> getPick(@LoginUserId Long userId,
 		@PathVariable Long pickId) {
 		return ResponseEntity.ok(
 			pickApiMapper.toApiResponse(
@@ -81,7 +81,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "401", description = "잘못된 태그 접근"),
 		@ApiResponse(responseCode = "403", description = "접근할 수 없는 폴더")
 	})
-	public ResponseEntity<PickApiResponse.Pick> savePick(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Pick> savePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Create request) {
 		return ResponseEntity.ok(
 			pickApiMapper.toApiResponse(pickService.saveNewPick(pickApiMapper.toCreateCommand(userId, request))));
@@ -92,7 +92,7 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "픽 내용 수정 성공")
 	})
-	public ResponseEntity<PickApiResponse.Pick> updatePick(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.Pick> updatePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Update request) {
 		return ResponseEntity.ok(
 			pickApiMapper.toApiResponse(pickService.updatePick(pickApiMapper.toUpdateCommand(userId, request))));
@@ -104,7 +104,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "204", description = "픽 이동 성공"),
 		@ApiResponse(responseCode = "400", description = "폴더가 존재하지 않음.")
 	})
-	public ResponseEntity<Void> movePick(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<Void> movePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Move request) {
 		pickService.movePick(pickApiMapper.toMoveCommand(userId, request));
 		return ResponseEntity.noContent().build();
@@ -117,7 +117,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "406", description = "휴지통이 아닌 폴더에서 픽 삭제 불가"),
 		@ApiResponse(responseCode = "500", description = "미확인 서버 에러 혹은 존재하지 않는 픽 삭제")
 	})
-	public ResponseEntity<Void> deletePick(@Parameter(hidden = true) @LoginUserId Long userId,
+	public ResponseEntity<Void> deletePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Delete request) {
 		pickService.deletePick(pickApiMapper.toDeleteCommand(userId, request));
 		return ResponseEntity.noContent().build();

--- a/backend/techpick-api/src/main/java/techpick/api/application/tag/controller/TagApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/tag/controller/TagApiController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import techpick.api.application.tag.dto.TagApiMapper;
 import techpick.api.application.tag.dto.TagApiRequest;
@@ -53,7 +54,7 @@ public class TagApiController {
 		@ApiResponse(responseCode = "400", description = "중복된 태그 이름", content = @Content(schema = @Schema()))
 	})
 	public ResponseEntity<TagApiResponse.Create> createTag(@LoginUserId Long userId,
-		@RequestBody TagApiRequest.Create request) {
+		@Valid @RequestBody TagApiRequest.Create request) {
 		return ResponseEntity.ok(
 			tagApiMapper.toCreateResponse(tagService.saveTag(tagApiMapper.toCreateCommand(userId, request))));
 	}
@@ -66,7 +67,7 @@ public class TagApiController {
 		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
 	})
 	public ResponseEntity<Void> updateTag(@LoginUserId Long userId,
-		@RequestBody TagApiRequest.Update request) {
+		@Valid @RequestBody TagApiRequest.Update request) {
 		tagService.updateTag(tagApiMapper.toUpdateCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -78,7 +79,7 @@ public class TagApiController {
 		@ApiResponse(responseCode = "401", description = "본인 태그만 이동할 수 있습니다.")
 	})
 	public ResponseEntity<Void> moveTag(@LoginUserId Long userId,
-		@RequestBody TagApiRequest.Move request) {
+		@Valid @RequestBody TagApiRequest.Move request) {
 		tagService.moveUserTag(tagApiMapper.toMoveCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -90,7 +91,7 @@ public class TagApiController {
 		@ApiResponse(responseCode = "401", description = "본인 태그만 삭제할 수 있습니다.")
 	})
 	public ResponseEntity<Void> deleteTag(@LoginUserId Long userId,
-		@RequestBody TagApiRequest.Delete request) {
+		@Valid @RequestBody TagApiRequest.Delete request) {
 		tagService.deleteTag(tagApiMapper.toDeleteCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/application/tag/controller/TagApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/tag/controller/TagApiController.java
@@ -7,12 +7,11 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,7 +38,7 @@ public class TagApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
-	public ResponseEntity<List<TagApiResponse.Read>> getAllUserTag(@Parameter(hidden = true) @LoginUserId Long userId) {
+	public ResponseEntity<List<TagApiResponse.Read>> getAllUserTag(@LoginUserId Long userId) {
 		return ResponseEntity.ok(
 			tagService.getUserTagList(userId).stream()
 				.map(tagApiMapper::toReadResponse)
@@ -53,8 +52,8 @@ public class TagApiController {
 		@ApiResponse(responseCode = "200", description = "태그 추가 성공"),
 		@ApiResponse(responseCode = "400", description = "중복된 태그 이름", content = @Content(schema = @Schema()))
 	})
-	public ResponseEntity<TagApiResponse.Create> createTag(@Parameter(hidden = true) @LoginUserId Long userId,
-		TagApiRequest.Create request) {
+	public ResponseEntity<TagApiResponse.Create> createTag(@LoginUserId Long userId,
+		@RequestBody TagApiRequest.Create request) {
 		return ResponseEntity.ok(
 			tagApiMapper.toCreateResponse(tagService.saveTag(tagApiMapper.toCreateCommand(userId, request))));
 	}
@@ -66,8 +65,8 @@ public class TagApiController {
 		@ApiResponse(responseCode = "400", description = "중복된 태그 이름"),
 		@ApiResponse(responseCode = "401", description = "본인 태그만 수정할 수 있습니다.")
 	})
-	public ResponseEntity<Void> updateTag(@Parameter(hidden = true) @LoginUserId Long userId,
-		TagApiRequest.Update request) {
+	public ResponseEntity<Void> updateTag(@LoginUserId Long userId,
+		@RequestBody TagApiRequest.Update request) {
 		tagService.updateTag(tagApiMapper.toUpdateCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -78,8 +77,8 @@ public class TagApiController {
 		@ApiResponse(responseCode = "204", description = "태그 이동 성공"),
 		@ApiResponse(responseCode = "401", description = "본인 태그만 이동할 수 있습니다.")
 	})
-	public ResponseEntity<Void> moveTag(@Parameter(hidden = true) @LoginUserId Long userId,
-		TagApiRequest.Move request) {
+	public ResponseEntity<Void> moveTag(@LoginUserId Long userId,
+		@RequestBody TagApiRequest.Move request) {
 		tagService.moveUserTag(tagApiMapper.toMoveCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}
@@ -90,8 +89,8 @@ public class TagApiController {
 		@ApiResponse(responseCode = "204", description = "태그 삭제 성공"),
 		@ApiResponse(responseCode = "401", description = "본인 태그만 삭제할 수 있습니다.")
 	})
-	public ResponseEntity<Void> deleteTag(@Parameter(hidden = true) @LoginUserId Long userId,
-		TagApiRequest.Delete request) {
+	public ResponseEntity<Void> deleteTag(@LoginUserId Long userId,
+		@RequestBody TagApiRequest.Delete request) {
 		tagService.deleteTag(tagApiMapper.toDeleteCommand(userId, request));
 		return ResponseEntity.noContent().build();
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
@@ -1,5 +1,6 @@
 package techpick.api.infrastructure.tag;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import techpick.api.domain.tag.dto.TagCommand;
 import techpick.api.domain.tag.dto.TagMapper;
 import techpick.api.domain.tag.exception.ApiTagException;
 import techpick.api.domain.user.exception.ApiUserException;
+import techpick.core.model.folder.Folder;
 import techpick.core.model.pick.PickRepository;
 import techpick.core.model.pick.PickTagRepository;
 import techpick.core.model.tag.Tag;
@@ -36,9 +38,15 @@ public class TagDataHandler {
 
 	@Transactional(readOnly = true)
 	public List<Tag> getTagList(Long userId) {
-		return tagRepository.findAllByUserId(userId);
+		User user = userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
+		List<Long> tagOrderList = user.getTagOrderList();
+		List<Tag> tagList = tagRepository.findAllByUserId(userId);
+		tagList.sort(Comparator.comparing(tag -> tagOrderList.indexOf(tag.getId())));
+
+		return tagList;
 	}
 
+	@Transactional(readOnly = true)
 	public List<Tag> getTagList(List<Long> tagOrderList) {
 		return tagRepository.findAllById(tagOrderList);
 	}

--- a/backend/techpick-security/src/main/java/techpick/security/annotation/LoginUserId.java
+++ b/backend/techpick-security/src/main/java/techpick/security/annotation/LoginUserId.java
@@ -5,6 +5,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(hidden = true)
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface LoginUserId {


### PR DESCRIPTION
- Close #382

## What is this PR? 🔍

- 기능 : Folder, Tag 리팩토링
- issue : #382

## Changes 📝
### 1. 태그 이동 후 조회 시 순서 보장되지 않는 문제 해결
DB 상에는 user의 태그 리스트 순서가 제대로 들어가는 것은 확인.
유저의 태그 리스트 조회 시 순서가 제대로 보장되지 않아 조회하는 부분에서 순서 보장되도록 해결
### 2. Folder, Tag API에 `@Valid`, `@RequestBody` 누락한 부분 수정
### 3. 각 API 파라미터에 `@Parameter(hidden = true)` 붙여야 하는 번거로움 해결
-> `@LoginUserId`에 `@Schema(hidden = true)`로 변경
### 4. api의 build.gradle에 있는 스웨거 설정 최상단으로 이동
