### PR TITLE
[REFACTOR] 폴더 멀티 이동 관련 버그 수정, Pick, Folder 변수명 통일

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiResponse.java
@@ -9,6 +9,6 @@ public record FolderApiResponse(
 	String name,
 	FolderType folderType,
 	Long parentFolderId,
-	List<Long> childFolderList
+	List<Long> childFolderIdOrderedList
 ) {
 }

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
@@ -11,7 +11,7 @@ public class PickApiRequest {
 	public record Create(
 		@Schema(example = "Record란?") String title,
 		@Schema(example = "Java 레코드에 관한 글") String memo,
-		@Schema(example = "[4, 5, 2, 1, 3]") List<Long> tagOrderList,
+		@Schema(example = "[4, 5, 2, 1, 3]") List<Long> tagIdList,
 		@Schema(example = "1") Long parentFolderId,
 		LinkInfo linkInfo
 	) {

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
@@ -11,7 +11,7 @@ public class PickApiRequest {
 	public record Create(
 		@Schema(example = "Record란?") String title,
 		@Schema(example = "Java 레코드에 관한 글") String memo,
-		@Schema(example = "[4, 5, 2, 1, 3]") List<Long> tagIdList,
+		@Schema(example = "[4, 5, 2, 1, 3]") List<Long> tagIdOrderedList,
 		@Schema(example = "1") Long parentFolderId,
 		LinkInfo linkInfo
 	) {
@@ -26,7 +26,7 @@ public class PickApiRequest {
 		@Schema(example = "1") @NotNull Long id,
 		@Schema(example = "Record란 뭘까?") String title,
 		@Schema(example = "Java Record") String memo,
-		@Schema(example = "[4, 5, 2, 1]") List<Long> tagIdList
+		@Schema(example = "[4, 5, 2, 1]") List<Long> tagIdOrderedList
 	) {
 	}
 

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
@@ -13,7 +13,7 @@ public class PickApiResponse {
 		String title,
 		String memo,
 		LinkInfo linkInfo,
-		List<Long> tagOrderList,
+		List<Long> tagIdOrderedList,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
 	) {

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderMapper.java
@@ -18,8 +18,8 @@ public interface FolderMapper {
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "parentFolder.id", target = "parentFolderId")
 	@Mapping(source = "user.id", target = "userId")
-	@Mapping(source = "childFolderOrderList", target = "childFolderList")
-	@Mapping(source = "childPickOrderList", target = "childPickList")
+	@Mapping(source = "childFolderIdOrderedList", target = "childFolderIdOrderedList")
+	@Mapping(source = "childPickIdOrderedList", target = "childPickIdOrderedList")
 	FolderResult toResult(Folder folder);
 
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderResult.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderResult.java
@@ -10,7 +10,7 @@ public record FolderResult(
 	FolderType folderType,
 	Long parentFolderId,
 	Long userId,
-	List<Long> childFolderList,
-	List<Long> childPickList
+	List<Long> childFolderIdOrderedList,
+	List<Long> childPickIdOrderedList
 ) {
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
@@ -12,11 +12,11 @@ public class PickCommand {
 	public record Search(Long userId, List<Long> folderIdList, List<String> searchTokenList) {
 	}
 
-	public record Create(Long userId, String title, String memo, List<Long> tagIdList, Long parentFolderId,
+	public record Create(Long userId, String title, String memo, List<Long> tagIdOrderedList, Long parentFolderId,
 						 LinkInfo linkInfo) {
 	}
 
-	public record Update(Long userId, Long id, String title, String memo, List<Long> tagIdList) {
+	public record Update(Long userId, Long id, String title, String memo, List<Long> tagIdOrderedList) {
 	}
 
 	public record Move(Long userId, List<Long> idList, Long destinationFolderId, int orderIdx) {

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
@@ -12,7 +12,7 @@ public class PickCommand {
 	public record Search(Long userId, List<Long> folderIdList, List<String> searchTokenList) {
 	}
 
-	public record Create(Long userId, String title, String memo, List<Long> tagOrderList, Long parentFolderId,
+	public record Create(Long userId, String title, String memo, List<Long> tagIdList, Long parentFolderId,
 						 LinkInfo linkInfo) {
 	}
 

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickMapper.java
@@ -30,6 +30,6 @@ public interface PickMapper {
 	@Mapping(source = "command.title", target = "title")
 	@Mapping(source = "parentFolder", target = "parentFolder")
 	@Mapping(source = "user", target = "user")
-	@Mapping(source = "command.tagIdList", target = "tagOrderList")
+	@Mapping(source = "command.tagIdOrderedList", target = "tagIdOrderedList")
 	Pick toEntity(PickCommand.Create command, User user, Folder parentFolder, Link link);
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickMapper.java
@@ -30,6 +30,6 @@ public interface PickMapper {
 	@Mapping(source = "command.title", target = "title")
 	@Mapping(source = "parentFolder", target = "parentFolder")
 	@Mapping(source = "user", target = "user")
-	@Mapping(source = "command.tagOrderList", target = "tagOrderList")
+	@Mapping(source = "command.tagIdList", target = "tagOrderList")
 	Pick toEntity(PickCommand.Create command, User user, Folder parentFolder, Link link);
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickResult.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickResult.java
@@ -13,7 +13,7 @@ public class PickResult {
 		String memo,
 		LinkInfo linkInfo,
 		Long parentFolderId,
-		List<Long> tagOrderList,
+		List<Long> tagIdOrderedList,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
 	) {

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
@@ -53,7 +53,7 @@ public class PickService {
 	public List<PickResult.Pick> getFolderChildPickList(Long userId, Long folderId) {
 		validateFolderAccess(userId, folderId);
 		Folder folder = folderDataHandler.getFolder(folderId);
-		List<Pick> pickList = pickDataHandler.getPickListPreservingOrder(folder.getChildPickOrderList());
+		List<Pick> pickList = pickDataHandler.getPickListPreservingOrder(folder.getChildPickIdOrderedList());
 
 		return pickList.stream()
 			.map(pickMapper::toPickResult)
@@ -77,9 +77,9 @@ public class PickService {
 		validateRootAccess(command.parentFolderId());
 		validateFolderAccess(command.userId(), command.parentFolderId());
 		var pick = pickDataHandler.savePick(command);
-		pick.getParentFolder().getChildPickOrderList().add(pick.getId());
+		pick.getParentFolder().getChildPickIdOrderedList().add(pick.getId());
 
-		List<Long> tagOrderList = pick.getTagOrderList();
+		List<Long> tagOrderList = pick.getTagIdOrderedList();
 		List<Tag> tagList = tagDataHandler.getTagList(tagOrderList);
 		for (Tag tag : tagList) {
 			if (ObjectUtils.notEqual(tag.getUser(), pick.getUser())) {
@@ -130,7 +130,7 @@ public class PickService {
 	 **/
 	private PickResult.FolderPickList getFolderChildPickResultList(Long folderId) {
 		Folder folder = folderDataHandler.getFolder(folderId);
-		List<Pick> pickList = pickDataHandler.getPickListPreservingOrder(folder.getChildPickOrderList());
+		List<Pick> pickList = pickDataHandler.getPickListPreservingOrder(folder.getChildPickIdOrderedList());
 		List<PickResult.Pick> pickResultList = pickList.stream()
 			.map(pickMapper::toPickResult)
 			.toList();

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -64,7 +64,7 @@ public class FolderDataHandler {
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 		Folder folder = folderRepository.save(Folder.createEmptyGeneralFolder(user, parentFolder, command.name()));
-		folder.getParentFolder().getChildFolderOrderList().add(folder.getId());
+		folder.getParentFolder().addChildFolderIdOrderedList(folder.getId());
 		return folder;
 	}
 
@@ -82,10 +82,8 @@ public class FolderDataHandler {
 		Folder parentFolder = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
-		parentFolder.getChildFolderOrderList().removeAll(command.idList());
-		parentFolder.getChildFolderOrderList().addAll(command.orderIdx(), command.idList());
-
-		return parentFolder.getChildFolderOrderList();
+		parentFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
+		return parentFolder.getChildFolderIdOrderedList();
 	}
 
 	@Transactional
@@ -94,15 +92,15 @@ public class FolderDataHandler {
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 		Folder oldParent = folder.getParentFolder();
-		oldParent.getChildFolderOrderList().removeAll(command.idList());
+		oldParent.getChildFolderIdOrderedList().removeAll(command.idList());
 
 		Folder newParent = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		newParent.getChildFolderOrderList().addAll(command.orderIdx(), command.idList());
+		newParent.getChildFolderIdOrderedList().addAll(command.orderIdx(), command.idList());
 
 		folder.updateParentFolder(newParent);
 
-		return newParent.getChildFolderOrderList();
+		return newParent.getChildFolderIdOrderedList();
 	}
 
 	@Transactional
@@ -115,7 +113,7 @@ public class FolderDataHandler {
 				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 			Folder parentFolder = folder.getParentFolder();
-			parentFolder.getChildFolderOrderList().remove(folder.getId());
+			parentFolder.getChildFolderIdOrderedList().remove(folder.getId());
 
 			deleteList.add(folder);
 		}

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -13,6 +13,7 @@ import techpick.api.domain.link.dto.LinkMapper;
 import techpick.api.domain.pick.dto.PickCommand;
 import techpick.api.domain.pick.dto.PickMapper;
 import techpick.api.domain.pick.exception.ApiPickException;
+import techpick.api.domain.tag.exception.ApiTagException;
 import techpick.api.domain.user.exception.ApiUserException;
 import techpick.core.model.folder.Folder;
 import techpick.core.model.folder.FolderRepository;
@@ -23,6 +24,7 @@ import techpick.core.model.pick.PickRepository;
 import techpick.core.model.pick.PickTag;
 import techpick.core.model.pick.PickTagRepository;
 import techpick.core.model.tag.Tag;
+import techpick.core.model.tag.TagRepository;
 import techpick.core.model.user.User;
 import techpick.core.model.user.UserRepository;
 
@@ -38,6 +40,7 @@ public class PickDataHandler {
 	private final FolderRepository folderRepository;
 	private final LinkRepository linkRepository;
 	private final LinkMapper linkMapper;
+	private final TagRepository tagRepository;
 
 	@Transactional(readOnly = true)
 	public Pick getPick(Long pickId) {
@@ -80,12 +83,18 @@ public class PickDataHandler {
 			})
 			.orElseGet(() -> linkRepository.save(linkMapper.of(command.linkInfo())));
 
+		// 픽 존재 여부 검증
 		pickRepository.findByUserAndLink(user, link)
 			.ifPresent((__) -> {
 				throw ApiPickException.PICK_MUST_BE_UNIQUE_FOR_A_URL();
 			});
 
-		return pickRepository.save(pickMapper.toEntity(command, user, folder, link));
+		// 태그 존재 여부 검증
+		validateTagIdList(command.tagIdOrderedList());
+
+		Pick savedPick = pickRepository.save(pickMapper.toEntity(command, user, folder, link));
+		savedPick.getParentFolder().addChildPickIdOrderedList(savedPick.getId());
+		return savedPick;
 	}
 
 	@Transactional
@@ -96,8 +105,12 @@ public class PickDataHandler {
 	@Transactional
 	public Pick updatePick(PickCommand.Update command) {
 		Pick pick = getPick(command.id());
+
+		// 태그 존재 여부 검증
+		validateTagIdList(command.tagIdOrderedList());
+
 		pick.updateTitle(command.title()).updateMemo(command.memo());
-		updateNewTagIdList(pick, command.tagIdList());
+		updateNewTagIdList(pick, command.tagIdOrderedList());
 		return pick;
 	}
 
@@ -106,7 +119,7 @@ public class PickDataHandler {
 		List<Long> pickIdList = command.idList();
 		Folder folder = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		folder.updateChildPickOrderList(pickIdList, command.orderIdx());
+		folder.updateChildPickIdOrderedList(pickIdList, command.orderIdx());
 	}
 
 	@Transactional
@@ -114,7 +127,7 @@ public class PickDataHandler {
 		List<Long> pickIdList = command.idList();
 		Folder destinationFolder = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		destinationFolder.updateChildPickOrderList(pickIdList, command.orderIdx());
+		destinationFolder.updateChildPickIdOrderedList(pickIdList, command.orderIdx());
 
 		for (Long pickId : pickIdList) {
 			Pick pick = getPick(pickId);
@@ -145,10 +158,16 @@ public class PickDataHandler {
 	}
 
 	private void updateNewTagIdList(Pick pick, List<Long> newTagOrderList) {
-		pick.getTagOrderList().stream()
+		pick.getTagIdOrderedList().stream()
 			.filter(tagId -> !newTagOrderList.contains(tagId))
 			.forEach(tagId -> detachTagFromPick(pick, tagId));
 		pick.updateTagOrderList(newTagOrderList);
+	}
+
+	private void validateTagIdList(List<Long> tagIdOrderedList) {
+		tagIdOrderedList
+			.forEach(tagId -> tagRepository.findById(tagId)
+				.orElseThrow(ApiTagException::TAG_NOT_FOUND));
 	}
 
 }

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
@@ -85,7 +85,7 @@ public class TagDataHandler {
 			.map(pickTag -> pickRepository.findById(pickTag.getPick().getId())
 				.orElseThrow(ApiTagException::TAG_NOT_FOUND))
 			.forEach(pick -> {
-				pick.getTagOrderList().remove(tagId);
+				pick.getTagIdOrderedList().remove(tagId);
 			});
 		pickTagRepository.deleteById(tagId);
 		tagRepository.deleteById(tagId);

--- a/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickServiceTest.java
+++ b/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickServiceTest.java
@@ -309,7 +309,7 @@ class PickServiceTest {
 
 			// then
 			assertThat(updatePick.title()).isNotEqualTo(savePick.title()).isEqualTo(newTitle); // changed
-			assertThat(updatePick.tagOrderList()).isNotEqualTo(savePick.tagOrderList())
+			assertThat(updatePick.tagIdOrderedList()).isNotEqualTo(savePick.tagIdOrderedList())
 				.isEqualTo(newTagOrder); // changed
 			assertThat(updatePick.memo()).isEqualTo(savePick.memo()); // unchanged
 		}
@@ -551,9 +551,9 @@ class PickServiceTest {
 			List<PickTag> pickTagList = pickDataHandler.getPickTagList(pickResult.id());
 
 			// then
-			assertThat(pickResult.tagOrderList().size()).isEqualTo(tagOrder.size() - 1);
-			assertThat(pickResult.tagOrderList().size()).isEqualTo(pickTagList.size());
-			assertThat(pickResult.tagOrderList()).isEqualTo(List.of(tag2.getId(), tag3.getId()));
+			assertThat(pickResult.tagIdOrderedList().size()).isEqualTo(tagOrder.size() - 1);
+			assertThat(pickResult.tagIdOrderedList().size()).isEqualTo(pickTagList.size());
+			assertThat(pickResult.tagIdOrderedList()).isEqualTo(List.of(tag2.getId(), tag3.getId()));
 		}
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
@@ -19,7 +19,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -59,13 +58,13 @@ public class Folder extends BaseEntity {
 	// ex) [6,3,2,23,1] -> "6 3 2 23 1"
 	@Convert(converter = OrderConverter.class)
 	@Column(name = "child_folder_order", columnDefinition = "longblob", nullable = false)
-	private List<Long> childFolderOrderList = new ArrayList<>();
+	private List<Long> childFolderIdOrderedList = new ArrayList<>();
 
 	// 폴더에 속한 pick id들을 공백으로 분리된 String으로 변환하여 db에 저장
 	// ex) [6,3,2,23,1] -> "6 3 2 23 1"
 	@Convert(converter = OrderConverter.class)
 	@Column(name = "pick_order", columnDefinition = "longblob", nullable = false)
-	private List<Long> childPickOrderList = new ArrayList<>();
+	private List<Long> childPickIdOrderedList = new ArrayList<>();
 
 	public static Folder createEmptyRootFolder(User user) {
 		return Folder.builder()
@@ -125,26 +124,41 @@ public class Folder extends BaseEntity {
 	}
 
 	public void updateChildFolderOrder(Long pickId, int destination) {
-		childFolderOrderList.remove(pickId);
-		childFolderOrderList.add(destination, pickId);
+		childFolderIdOrderedList.remove(pickId);
+		childFolderIdOrderedList.add(destination, pickId);
 	}
 
 	public void updateChildPickOrder(Long pickId, int destination) {
-		childPickOrderList.remove(pickId);
-		childPickOrderList.add(destination, pickId);
+		childPickIdOrderedList.remove(pickId);
+		childPickIdOrderedList.add(destination, pickId);
 	}
 
-	public void updateChildPickOrderList(List<Long> pickIdList, int destination) {
-		childPickOrderList.removeAll(pickIdList);
-		childPickOrderList.addAll(destination, pickIdList);
+	public void updateChildPickIdOrderedList(List<Long> pickIdList, int destination) {
+		childPickIdOrderedList.removeAll(pickIdList);
+		int calculatedDestination = Math.min(destination, childPickIdOrderedList.size());
+		childPickIdOrderedList.addAll(calculatedDestination, pickIdList);
+	}
+
+	public void updateChildFolderIdOrderedList(List<Long> folderIdList, int destination) {
+		childFolderIdOrderedList.removeAll(folderIdList);
+		int calculatedDestination = Math.min(destination, childFolderIdOrderedList.size());
+		childFolderIdOrderedList.addAll(calculatedDestination, folderIdList);
+	}
+
+	public void addChildPickIdOrderedList(Long pickId) {
+		childPickIdOrderedList.add(0, pickId);
+	}
+
+	public void addChildFolderIdOrderedList(Long folderId) {
+		childFolderIdOrderedList.add(0, folderId);
 	}
 
 	public void removeChildFolderOrder(Long folderId) {
-		this.childFolderOrderList.remove(folderId);
+		this.childFolderIdOrderedList.remove(folderId);
 	}
 
 	public void removeChildPickOrder(Long pickId) {
-		this.childPickOrderList.remove(pickId);
+		this.childPickIdOrderedList.remove(pickId);
 	}
 
 	@Builder
@@ -153,14 +167,14 @@ public class Folder extends BaseEntity {
 		FolderType folderType,
 		Folder parentFolder,
 		User user,
-		List<Long> childFolderOrderList,
-		List<Long> childPickOrderList
+		List<Long> childFolderIdOrderedList,
+		List<Long> childPickIdOrderedList
 	) {
 		this.name = name;
 		this.folderType = folderType;
 		this.parentFolder = parentFolder;
 		this.user = user;
-		this.childFolderOrderList = childFolderOrderList != null ? childFolderOrderList : new ArrayList<>();
-		this.childPickOrderList = childPickOrderList != null ? childPickOrderList : new ArrayList<>();
+		this.childFolderIdOrderedList = childFolderIdOrderedList != null ? childFolderIdOrderedList : new ArrayList<>();
+		this.childPickIdOrderedList = childPickIdOrderedList != null ? childPickIdOrderedList : new ArrayList<>();
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
@@ -69,26 +69,26 @@ public class Pick extends BaseEntity {
 	// 픽에 속한 tag id들을 공백으로 분리된 String으로 변환하여 db에 저장. Ex) [6,3,2,23,1] -> "6 3 2 23 1"
 	@Convert(converter = OrderConverter.class)
 	@Column(name = "tag_order", columnDefinition = "longblob", nullable = false)
-	private List<Long> tagOrderList = new ArrayList<>();
+	private List<Long> tagIdOrderedList = new ArrayList<>();
 
 	// 사용자가 링크에 대해 남기는 메모 (update시 null과 ""를 구분하기 위함)
 	@Column(name = "memo", nullable = false)
 	private String memo = "";
 
 	@Builder
-	private Pick(User user, Link link, Folder parentFolder, String title, List<Long> tagOrderList, String memo) {
+	private Pick(User user, Link link, Folder parentFolder, String title, List<Long> tagIdOrderedList, String memo) {
 		this.user = user;
 		this.link = link;
 		this.parentFolder = parentFolder;
 		this.title = title;
-		this.tagOrderList = tagOrderList;
+		this.tagIdOrderedList = tagIdOrderedList;
 		this.memo = memo;
 	}
 
 	public Pick updateTagOrderList(List<Long> tagOrderList) {
 		if (tagOrderList == null)
 			return this;
-		this.tagOrderList = tagOrderList;
+		this.tagIdOrderedList = tagOrderList;
 		return this;
 	}
 


### PR DESCRIPTION
- Close #386

## What is this PR? 🔍

- 기능 : 폴더 멀티 이동 관련 버그 수정, Pick, Folder 리팩토링
- issue : #386

## Changes 📝
### 1. Pick 변수명 통일
- Pick Entity, Dto
`tagOrderList` -> `tagIdOrderedList`로 변경

### 2. Folder 변수명 통일
- Folder Entity, Dto 
`childFolderOrderList` -> `childFolderIdOrderedList`로 변경
`childPickOrderList` -> `childPickIdOrderedList`로 변경

### 3. 픽 생성, 수정 시 태그 리스트에 있는 태그들 존재하는지 검증하는 로직 추가
- 변경 전 : 픽 생성, 수정 시 태그가 없어도 픽이 생성되는 문제 발생
- 변경 후 : 픽 생성, 수정 시 태그가 존재하는지 검증하는 로직 추가 

### 4. 폴더, 픽 생성 시 리스트 맨 앞에 추가하도록 변경
- 변경 전 : ArrayList `가장 마지막 인덱스`에 추가
- 변경 후 : ArrayList `0번 인덱스`에 추가

`Folder.java`
```java
	public void addChildPickIdOrderedList(Long pickId) {
		childPickIdOrderedList.add(0, pickId);
	}

	public void addChildFolderIdOrderedList(Long folderId) {
		childFolderIdOrderedList.add(0, folderId);
	}
```

### 5. 폴더, 픽 여러 개 이동이 되지 않는 문제 해결
`FolderService.java`
```java
	@Transactional
	public void moveFolder(FolderCommand.Move command) {
		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());

		for (Folder folder : folderList) {
			validateFolderAccess(command.userId(), folder);
			validateBasicFolderChange(folder);
		}

		// 부모가 다른 폴더들을 동시에 이동할 수 없음.
		// 수정 부분
		Long destinationFolderId = command.destinationFolderId();
		for (Folder folder : folderList) {
			Long parentFolderId = folder.getParentFolder().getId();
			if (ObjectUtils.notEqual(destinationFolderId, parentFolderId)) {
				throw ApiFolderException.INVALID_MOVE_TARGET();
			}
		}

		if (isParentFolderNotChanged(command, destinationFolderId)) {
			folderDataHandler.moveFolderWithinParent(command);
		} else {
			folderDataHandler.moveFolderToDifferentParent(command);
		}
	}
```
destinationFolderId와 비교해야 하는데 첫 번째 리스트의 부모 폴더 id를 꺼내서 비교하고 있었음.
-> `destinationFolderId`과 `폴더 리스트에 있는 각각의 부모 폴더 id와 비교`하도록 변경
- - -
`FolderDataHandler.java`
```java
	@Transactional
	public List<Long> moveFolderWithinParent(FolderCommand.Move command) {
		Folder parentFolder = folderRepository.findById(command.destinationFolderId())
			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);

		parentFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
		return parentFolder.getChildFolderIdOrderedList();
	}
```
- - -
`Folder.java`
```java
	public void updateChildPickIdOrderedList(List<Long> pickIdList, int destination) {
		childPickIdOrderedList.removeAll(pickIdList);
		int calculatedDestination = Math.min(destination, childPickIdOrderedList.size());
		childPickIdOrderedList.addAll(calculatedDestination, pickIdList);
	}

	public void updateChildFolderIdOrderedList(List<Long> folderIdList, int destination) {
		childFolderIdOrderedList.removeAll(folderIdList);
		int calculatedDestination = Math.min(destination, childFolderIdOrderedList.size());
		childFolderIdOrderedList.addAll(calculatedDestination, folderIdList);
	}
```
removeAll 후 addAll을 하게 되면, ArrayList의 크기가 줄어들게 되어 `IndexOutOfBoundsException` 발생

예시) folderIdList :  [2, 3, 4, 5, 6], 이동할 idList : [3, 4, 5], orderIdx : 4

예상되는 결과 값 : [2, 6, 3, 4, 5]
실제 결과 값 : `IndexOutOfBoundsException`

- 원인
1. removeAll 하여 ArrayList size가 2로 줄어들게 되었음.
2. size가 2인 상황에서 index 4에 add를 하려고 하니 문제가 발생

- 해결
1. orderIdx와 ArrayList 크기를 비교한다.
2. 둘 중 더 작은 값을 찾아 그 값을 인덱스로 활용한다.
3. orderIdx : 4, ArrayList.size() : 2이면, ArrayList 사이즈를 고려하여 인덱스 2번에 값들을 추가하도록 한다.
4. orderIdx : 2, ArrayList.size() : 4이면, ArrayList 사이즈와 상관 없이 인덱스 2번에 값들을 추가할 수 있다.
