### PR TITLE
[FIX] 다른 폴더로 이동되지 않는 문제, 스웨거 응답 예시 추가

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiConstant.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiConstant.java
@@ -1,0 +1,24 @@
+package techpick.api.application.folder.controller;
+
+public class FolderApiConstant {
+
+	public static final String ROOT_FOLDER_EXAMPLE = """
+		[
+		    {
+		        "id": 1,
+		        "name": "Root Folder",
+		        "folderType": "ROOT",
+		        "parentFolderId": null,
+		        "childFolderIdOrderedList": [4]
+		    },
+		    {
+		        "id": 4,
+		        "name": "General Folder",
+		        "folderType": "GENERAL",
+		        "parentFolderId": 1,
+		        "childFolderIdOrderedList": []
+		    }
+		]
+		""";
+
+}

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
@@ -13,7 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,7 +38,12 @@ public class FolderApiController {
 	@GetMapping
 	@Operation(summary = "루트 폴더와 하위 리스트 조회", description = "사용자의 루트 폴더와 루트 하위 전체 폴더를 조회합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "200",
+			description = "조회 성공",
+			content = @Content(
+				mediaType = "application/json",
+				examples = @ExampleObject(value = FolderApiConstant.ROOT_FOLDER_EXAMPLE)
+			)),
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 조회할 수 있습니다.")
 	})
 	public ResponseEntity<List<FolderApiResponse>> getAllRootFolderList(@LoginUserId Long userId) {

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiResponse.java
@@ -2,11 +2,13 @@ package techpick.api.application.folder.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import techpick.core.model.folder.FolderType;
 
 public record FolderApiResponse(
 	Long id,
 	String name,
+	@Schema(example = "GENERAL")
 	FolderType folderType,
 	Long parentFolderId,
 	List<Long> childFolderIdOrderedList

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -97,16 +97,8 @@ public class FolderService {
 			validateBasicFolderChange(folder);
 		}
 
-		// 부모가 다른 폴더들을 동시에 이동할 수 없음.
-		Long destinationFolderId = command.destinationFolderId();
-		for (Folder folder : folderList) {
-			Long parentFolderId = folder.getParentFolder().getId();
-			if (ObjectUtils.notEqual(destinationFolderId, parentFolderId)) {
-				throw ApiFolderException.INVALID_MOVE_TARGET();
-			}
-		}
-
-		if (isParentFolderNotChanged(command, destinationFolderId)) {
+		Long parentFolderId = folderList.get(0).getParentFolder().getId();
+		if (isParentFolderNotChanged(command, parentFolderId)) {
 			folderDataHandler.moveFolderWithinParent(command);
 		} else {
 			folderDataHandler.moveFolderToDifferentParent(command);

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -99,6 +99,8 @@ public class FolderService {
 		}
 
 		Folder destinationFolder = folderDataHandler.getFolder(command.destinationFolderId());
+		// TODO: 현재 프론트에서 같은 부모 폴더에서만 폴더들을 선택하여 이동할 수 있음.
+		//  추후 다른 부모 폴더도 선택이 가능해지게 된다면, get(0) 사용하는 방식이 아닌 다른 방식을 고려해야 함.
 		Long parentFolderId = folderList.get(0).getParentFolder().getId();
 		if (isParentFolderNotChanged(command, parentFolderId)) {
 			validateWithinParentFolder(folderList, destinationFolder);

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -3,9 +3,7 @@ package techpick.api.infrastructure.folder;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,14 +82,6 @@ public class FolderDataHandler {
 		Long destinationFolderId = command.destinationFolderId();
 		Folder destinationFolder = folderRepository.findById(destinationFolderId)
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		List<Folder> folderList = getFolderList(command.idList());
-
-		for (Folder parentFolder : folderList) {
-			Long parentFolderId = parentFolder.getParentFolder().getId();
-			if (ObjectUtils.notEqual(parentFolderId, destinationFolderId)) {
-				throw ApiFolderException.INVALID_MOVE_TARGET();
-			}
-		}
 
 		destinationFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
 		return destinationFolder.getChildFolderIdOrderedList();
@@ -110,12 +100,7 @@ public class FolderDataHandler {
 		newParent.addChildFolderIdOrderedList(command.idList(), command.orderIdx());
 
 		List<Folder> folderList = getFolderList(command.idList());
-		Long destinationFolderId = command.destinationFolderId();
 		for (Folder moveFolder : folderList) {
-			Long parentFolderId = moveFolder.getParentFolder().getId();
-			if (Objects.equals(parentFolderId, destinationFolderId)) {
-				throw ApiFolderException.INVALID_MOVE_TARGET();
-			}
 			moveFolder.updateParentFolder(newParent);
 		}
 

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -93,7 +93,7 @@ public class PickDataHandler {
 		validateTagIdList(command.tagIdOrderedList());
 
 		Pick savedPick = pickRepository.save(pickMapper.toEntity(command, user, folder, link));
-		savedPick.getParentFolder().addChildPickIdOrderedList(savedPick.getId());
+		savedPick.getParentFolder().addChildPickIdOrdered(savedPick.getId());
 		return savedPick;
 	}
 

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
@@ -145,12 +145,17 @@ public class Folder extends BaseEntity {
 		childFolderIdOrderedList.addAll(calculatedDestination, folderIdList);
 	}
 
-	public void addChildPickIdOrderedList(Long pickId) {
+	public void addChildPickIdOrdered(Long pickId) {
 		childPickIdOrderedList.add(0, pickId);
 	}
 
-	public void addChildFolderIdOrderedList(Long folderId) {
+	public void addChildFolderIdOrdered(Long folderId) {
 		childFolderIdOrderedList.add(0, folderId);
+	}
+
+	public void addChildFolderIdOrderedList(List<Long> folderIdList, int destination) {
+		int calculatedDestination = Math.min(destination, childFolderIdOrderedList.size());
+		childFolderIdOrderedList.addAll(calculatedDestination, folderIdList);
 	}
 
 	public void removeChildFolderOrder(Long folderId) {


### PR DESCRIPTION
- Close #395 

## What is this PR? 🔍

- 기능 : 다른 폴더로 이동되지 않는 문제, 스웨거 응답 예시 추가
- issue : #395 

## Changes 📝
### 1. 스웨거 응답 예시 추가
`FolderApiResponse` : 변수에 `@Schema(example = "GENERAL")` 명시
`FolderApiController` : `@ExampleObject` 사용하여 응답 예시 구체화
```java
	@GetMapping
	@Operation(summary = "루트 폴더와 하위 리스트 조회", description = "사용자의 루트 폴더와 루트 하위 전체 폴더를 조회합니다.")
	@ApiResponses(value = {
		@ApiResponse(responseCode = "200",
			description = "조회 성공",
			content = @Content(
				mediaType = "application/json",
				examples = @ExampleObject(value = FolderApiConstant.ROOT_FOLDER_EXAMPLE)
			)),
		@ApiResponse(responseCode = "401", description = "본인 폴더만 조회할 수 있습니다.")
	})
```
`@ExampleObject`에 사용되는 문자열 Json을 컨트롤러에 작성하다보니 너무 지저분해지고 있습니다.
클래스(`FolderApiConstant`) 따로 분리하여 `클래스 내부에 상수로 정의`하여 사용하도록 하였습니다.

우선 하나의 api에만 적용하고, 프론트 측에서 필요로 할 때 추가로 작성하는 것으로 하겠습니다.

### 2. 폴더 이동 시 다른 폴더로 이동 되지 않는 문제
기존에 `FolderService`에서 같은 폴더로만 이동이 가능하도록 로직이 작성되어 있었음.
`이동하고자 하는 폴더 id`와 `부모 폴더 id`가 일치하지 않아 exception을 발생하여 다른 폴더로 이동되지 않았음.

`FolderService`에서 검증하는 것이 아니라 `FolderDataHandler`에서 각각 검증하도록 변경하였음.
같은 폴더인 경우 : `destinationFolderId != parentFolderId` -> 예외 발생
다른 폴더인 경우 : `destinationFolderId == parentFolderId` -> 예외 발생

검증 로직이 FolderService에 있어야 하는 것은 맞지만, 당장 떠오르지 않아 우선 구현하였습니다.
개선 방법에 대해 의견 주시면 감사하겠습니다.
