### PR TITLE
[FEAT] pick bulk insert 구현 및 테스트 작성

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickBulkService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickBulkService.java
@@ -1,0 +1,31 @@
+package techpick.api.domain.pick.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import techpick.api.domain.link.dto.LinkInfo;
+import techpick.api.domain.pick.dto.PickCommand;
+import techpick.api.infrastructure.pick.PickBulkDataHandler;
+
+@Service
+@RequiredArgsConstructor
+public class PickBulkService {
+
+	private final PickBulkDataHandler pickBulkDataHandler;
+
+	@Transactional
+	public void saveBulkPick(Long userId, Long parentFolderId) {
+		List<PickCommand.Create> pickList = new ArrayList<>();
+		for (int i = 0; i < 10000; i++) {
+			LinkInfo linkInfo = new LinkInfo(String.valueOf(i), "링크 제목", "링크 설명", "링크 이미지 url", null);
+			PickCommand.Create command = new PickCommand.Create(userId, "테스트 제목", "테스트 메모", new ArrayList<>(),
+				parentFolderId, linkInfo);
+			pickList.add(command);
+		}
+		pickBulkDataHandler.bulkInsertPick(pickList);
+	}
+}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
@@ -1,6 +1,5 @@
 package techpick.api.domain.pick.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -11,14 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import techpick.api.domain.folder.exception.ApiFolderException;
-import techpick.api.domain.link.dto.LinkInfo;
 import techpick.api.domain.pick.dto.PickCommand;
 import techpick.api.domain.pick.dto.PickMapper;
 import techpick.api.domain.pick.dto.PickResult;
 import techpick.api.domain.pick.exception.ApiPickException;
 import techpick.api.domain.tag.exception.ApiTagException;
 import techpick.api.infrastructure.folder.FolderDataHandler;
-import techpick.api.infrastructure.pick.PickBulkRepository;
 import techpick.api.infrastructure.pick.PickDataHandler;
 import techpick.api.infrastructure.tag.TagDataHandler;
 import techpick.core.model.folder.Folder;
@@ -34,7 +31,6 @@ public class PickService {
 	private final TagDataHandler tagDataHandler;
 	private final PickDataHandler pickDataHandler;
 	private final PickMapper pickMapper;
-	private final PickBulkRepository pickBulkRepository;
 	private final FolderDataHandler folderDataHandler;
 
 	@Transactional(readOnly = true)
@@ -127,18 +123,6 @@ public class PickService {
 		}
 
 		pickDataHandler.deletePickList(command);
-	}
-
-	@Transactional
-	public void saveBulkPick(Long userId, Long parentFolderId) {
-		List<PickCommand.Create> pickList = new ArrayList<>();
-		for (int i = 0; i < 10000; i++) {
-			LinkInfo linkInfo = new LinkInfo(String.valueOf(i), "링크 제목", "링크 설명", "링크 이미지 url", null);
-			PickCommand.Create command = new PickCommand.Create(userId, "테스트 제목", "테스트 메모", new ArrayList<>(),
-				parentFolderId, linkInfo);
-			pickList.add(command);
-		}
-		pickBulkRepository.bulkInsertPick(pickList);
 	}
 
 	/**

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
@@ -1,5 +1,6 @@
 package techpick.api.domain.pick.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -10,12 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import techpick.api.domain.folder.exception.ApiFolderException;
+import techpick.api.domain.link.dto.LinkInfo;
 import techpick.api.domain.pick.dto.PickCommand;
 import techpick.api.domain.pick.dto.PickMapper;
 import techpick.api.domain.pick.dto.PickResult;
 import techpick.api.domain.pick.exception.ApiPickException;
 import techpick.api.domain.tag.exception.ApiTagException;
 import techpick.api.infrastructure.folder.FolderDataHandler;
+import techpick.api.infrastructure.pick.PickBulkRepository;
 import techpick.api.infrastructure.pick.PickDataHandler;
 import techpick.api.infrastructure.tag.TagDataHandler;
 import techpick.core.model.folder.Folder;
@@ -30,8 +33,9 @@ public class PickService {
 
 	private final TagDataHandler tagDataHandler;
 	private final PickDataHandler pickDataHandler;
-	private final FolderDataHandler folderDataHandler;
 	private final PickMapper pickMapper;
+	private final PickBulkRepository pickBulkRepository;
+	private final FolderDataHandler folderDataHandler;
 
 	@Transactional(readOnly = true)
 	public PickResult.Pick getPick(PickCommand.Read command) {
@@ -123,6 +127,18 @@ public class PickService {
 		}
 
 		pickDataHandler.deletePickList(command);
+	}
+
+	@Transactional
+	public void saveBulkPick(Long userId, Long parentFolderId) {
+		List<PickCommand.Create> pickList = new ArrayList<>();
+		for (int i = 0; i < 10000; i++) {
+			LinkInfo linkInfo = new LinkInfo(String.valueOf(i), "링크 제목", "링크 설명", "링크 이미지 url", null);
+			PickCommand.Create command = new PickCommand.Create(userId, "테스트 제목", "테스트 메모", new ArrayList<>(),
+				parentFolderId, linkInfo);
+			pickList.add(command);
+		}
+		pickBulkRepository.bulkInsertPick(pickList);
 	}
 
 	/**

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickBulkDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickBulkDataHandler.java
@@ -18,7 +18,7 @@ import techpick.core.model.link.LinkRepository;
 
 @Repository
 @RequiredArgsConstructor
-public class PickBulkRepository {
+public class PickBulkDataHandler {
 
 	private final JdbcTemplate jdbcTemplate;
 	private final LinkRepository linkRepository;

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickBulkRepository.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickBulkRepository.java
@@ -1,0 +1,67 @@
+package techpick.api.infrastructure.pick;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import techpick.api.domain.link.dto.LinkInfo;
+import techpick.api.domain.pick.dto.PickCommand;
+import techpick.core.model.link.Link;
+import techpick.core.model.link.LinkRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class PickBulkRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final LinkRepository linkRepository;
+
+	@Transactional
+	public Link getOrCreateLink(LinkInfo linkInfo) {
+		return linkRepository.findByUrl(linkInfo.url())
+			.orElseGet(() -> {
+				Link link = Link.builder()
+					.url(linkInfo.url())
+					.title(linkInfo.title())
+					.description(linkInfo.description())
+					.imageUrl(linkInfo.imageUrl())
+					.invalidatedAt(linkInfo.invalidatedAt())
+					.build();
+				return linkRepository.save(link);
+			});
+	}
+
+	@Transactional
+	public void bulkInsertPick(List<PickCommand.Create> pickList) {
+		String sql = "INSERT INTO pick (user_id, link_id, parent_folder_id, title, tag_order, memo, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				PickCommand.Create pick = pickList.get(i);
+				Link link = getOrCreateLink(pick.linkInfo());
+				ps.setLong(1, pick.userId());
+				ps.setLong(2, link.getId());
+				ps.setLong(3, pick.parentFolderId());
+				ps.setString(4, pick.title());
+				ps.setString(5,
+					String.join(" ", pick.tagIdOrderedList().stream().map(String::valueOf).toArray(String[]::new)));
+				ps.setString(6, pick.memo());
+				ps.setString(7, String.valueOf(LocalDateTime.now()));
+				ps.setString(8, String.valueOf(LocalDateTime.now()));
+			}
+
+			@Override
+			public int getBatchSize() {
+				return pickList.size();
+			}
+		});
+	}
+}

--- a/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickBulkInsertTest.java
+++ b/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickBulkInsertTest.java
@@ -28,6 +28,9 @@ class PickBulkInsertTest {
 	@Autowired
 	PickService pickService;
 
+	@Autowired
+	PickBulkService pickBulkService;
+
 	User user;
 	Folder root, recycleBin, unclassified, general;
 
@@ -61,7 +64,7 @@ class PickBulkInsertTest {
 	@DisplayName("픽 10000개 bulk insert test")
 	void pickBulkInsertTest() {
 		long start = System.currentTimeMillis();
-		pickService.saveBulkPick(user.getId(), unclassified.getId());
+		pickBulkService.saveBulkPick(user.getId(), unclassified.getId());
 		long end = System.currentTimeMillis();
 
 		log.info("bulk insert time : {}", (end - start));

--- a/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickBulkInsertTest.java
+++ b/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickBulkInsertTest.java
@@ -1,0 +1,84 @@
+package techpick.api.domain.pick.service;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import lombok.extern.slf4j.Slf4j;
+import techpick.TechPickApiApplication;
+import techpick.api.domain.link.dto.LinkInfo;
+import techpick.api.domain.pick.dto.PickCommand;
+import techpick.core.model.folder.Folder;
+import techpick.core.model.folder.FolderRepository;
+import techpick.core.model.user.Role;
+import techpick.core.model.user.SocialType;
+import techpick.core.model.user.User;
+import techpick.core.model.user.UserRepository;
+
+@Slf4j
+@SpringBootTest(classes = TechPickApiApplication.class)
+@ActiveProfiles("local")
+class PickBulkInsertTest {
+
+	@Autowired
+	PickService pickService;
+
+	User user;
+	Folder root, recycleBin, unclassified, general;
+
+	@BeforeEach
+		// TODO: change to Adaptor
+	void setUp(
+		@Autowired UserRepository userRepository,
+		@Autowired FolderRepository folderRepository
+	) {
+		// save test user
+		user = userRepository.save(
+			User.builder()
+				.email("test@test.com")
+				.nickname("test")
+				.password("test")
+				.role(Role.ROLE_USER)
+				.socialProvider(SocialType.KAKAO)
+				.socialProviderId("1")
+				.tagOrderList(new ArrayList<>())
+				.build()
+		);
+
+		// save test folder
+		root = folderRepository.save(Folder.createEmptyRootFolder(user));
+		recycleBin = folderRepository.save(Folder.createEmptyRecycleBinFolder(user));
+		unclassified = folderRepository.save(Folder.createEmptyUnclassifiedFolder(user));
+		general = folderRepository.save(Folder.createEmptyGeneralFolder(user, root, "React.js"));
+	}
+
+	@Test
+	@DisplayName("픽 10000개 bulk insert test")
+	void pickBulkInsertTest() {
+		long start = System.currentTimeMillis();
+		pickService.saveBulkPick(user.getId(), unclassified.getId());
+		long end = System.currentTimeMillis();
+
+		log.info("bulk insert time : {}", (end - start));
+	}
+
+	@Test
+	@DisplayName("픽 10000개 normal insert test")
+	void pickInsertTest() {
+		long start = System.currentTimeMillis();
+		for (int i = 0; i < 10000; i++) {
+			LinkInfo linkInfo = new LinkInfo("test" + i, "링크 제목", "링크 설명", "링크 이미지 url", null);
+			PickCommand.Create command = new PickCommand.Create(user.getId(), "테스트 제목", "테스트 메모", new ArrayList<>(),
+				unclassified.getId(), linkInfo);
+			pickService.saveNewPick(command);
+		}
+		long end = System.currentTimeMillis();
+
+		log.info("normal insert time : {}", (end - start));
+	}
+}


### PR DESCRIPTION
- Close #407 

## What is this PR? 🔍

- 기능 : pick bulk insert 구현 및 테스트 작성
- issue : #407 

## Changes 📝
- insert 10000번 vs bulk insert 1번에 대한 시간 소요 측정
- JPA에서 bulk insert를 지원하지 않아 `JdbcTemplate`을 사용하여 구현
- #408 측정 결과 참고


PickBulkRepository 위치가 infrastructure에 위치하고 있습니다. core 쪽으로 이동시키는게 맞을까요?
