### PR TITLE
[FEAT] JSON 파싱 관련 예외 추가 및 요청-응답 로깅 필터 구현

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/filter/ApiRequestResponseLoggingFilter.java
+++ b/backend/techpick-api/src/main/java/techpick/api/filter/ApiRequestResponseLoggingFilter.java
@@ -1,0 +1,63 @@
+package techpick.api.filter;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiRequestResponseLoggingFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		long startTime = System.currentTimeMillis();
+
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			long executionTime = System.currentTimeMillis() - startTime;
+			String url = request.getRequestURI();
+			String method = request.getMethod();
+
+			if (url.startsWith("/api/")) {
+				var logInfo = new RequestResponseLogInfo(url, method, executionTime);
+				log.info(logInfo.toString());
+			}
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	private static class RequestResponseLogInfo {
+		private String url;
+		private String httpMethod;
+		private Long executionTime;
+
+		@Override
+		public String toString() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			try {
+				return objectMapper.writeValueAsString(this);
+			} catch (JsonProcessingException e) {
+				return e.getMessage();
+			}
+		}
+	}
+}
+

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
@@ -2,7 +2,6 @@ package techpick.core.exception.base;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 public class ApiErrorResponse extends ResponseEntity<ApiErrorBody> {
 
@@ -27,5 +26,9 @@ public class ApiErrorResponse extends ResponseEntity<ApiErrorBody> {
 
 	public static ApiErrorResponse UNKNOWN_SERVER_ERROR() {
 		return new ApiErrorResponse("UNKNOWN", "미확인 서버 에러", HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	public static ApiErrorResponse INVALID_JSON_ERROR() {
+		return new ApiErrorResponse("INVALID JSON ERROR", "올바르지 않은 Json 형식입니다.", HttpStatus.BAD_REQUEST);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package techpick.core.exception.base;
 
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -27,6 +28,13 @@ public class ApiExceptionHandler {
 	public ApiErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
 		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception);
 		return ApiErrorResponse.VALIDATION_ERROR();
+	}
+
+	// Json 파싱 과정 중 에러가 났을때 처리하는 handler
+	// 참고 : https://be-student.tistory.com/52
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ApiErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
+		return ApiErrorResponse.INVALID_JSON_ERROR();
 	}
 
 	/**


### PR DESCRIPTION
- Close #390

## What is this PR? 🔍

- 기능 : JSON 파싱 관련 예외 추가 및 요청-응답 로깅 필터 구현
- issue : #390

## Changes 📝

### JSON 파싱 관련 예외 추가
기존에는 Json 형식에 오류가 있어 파싱 실패시 500에러가 발생
-> 프론트에서 예외처리 하기 힘듬
이를해결하기위해
- Json 파싱 실패 시 발생하는 `HttpMessageNotReadableException`을 처리할 수 있는 ExceptionHandler 추가
- `INVALID_JSON_ERROR` 추가

### 요청 - 응답 로깅을 위한 필터 추가
각 api별 호출 횟수 및 실행시간을 측정하기 위한 `ApiRequestResponseLoggingFilter`구현
`/api/`로 시작되는 요청의 다음 정보들을 로깅
- URL
- HTTP Method
- 실행시간

## TODO
이거저거 고민 해봤는데 어떤 항목을 로깅하는게 좋을지 떠오르지 않아서 일단 가장 기본이 되는 api쪽만 로깅을 구현해봤습니다.
추가적으로 로깅했으면 하는 항목이 있다면 알려주세요.