### PR TITLE
[REFACTOR] 시큐리티 및 예외처리 리팩토링

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/config/SwaggerConfig.java
+++ b/backend/techpick-api/src/main/java/techpick/api/config/SwaggerConfig.java
@@ -2,7 +2,6 @@ package techpick.api.config;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,12 +10,16 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import techpick.security.config.SecurityProperties;
 
 @Configuration
 public class SwaggerConfig {
 
-	@Value("${core.base-url}")
-	private String baseUrl;
+	private final SecurityProperties properties;
+
+	public SwaggerConfig(SecurityProperties properties) {
+		this.properties = properties;
+	}
 
 	@Bean
 	public OpenAPI openAPI() {
@@ -47,8 +50,6 @@ public class SwaggerConfig {
 	}
 
 	private Server getServer() {
-		// TODO: AWS배포 이후 local prod에 따라 다른 url 적용하도록 리팩토링 필요
-		// 현재는 홈서버 반환
-		return new Server().url(baseUrl);
+		return new Server().url(properties.getBaseUrl());
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
@@ -2,7 +2,6 @@ package techpick.core.exception.base;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 public class ApiErrorResponse extends ResponseEntity<ApiErrorBody> {
 
@@ -27,5 +26,9 @@ public class ApiErrorResponse extends ResponseEntity<ApiErrorBody> {
 
 	public static ApiErrorResponse UNKNOWN_SERVER_ERROR() {
 		return new ApiErrorResponse("UNKNOWN", "미확인 서버 에러", HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	public static ApiErrorResponse INVALID_JSON_ERROR() {
+		return new ApiErrorResponse("INVALID JSON ERROR", "올바르지 않은 Json 형식입니다.", HttpStatus.BAD_REQUEST);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package techpick.core.exception.base;
 
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -38,5 +39,13 @@ public class ApiExceptionHandler {
 		exception.handleErrorByLevel();
 
 		return ApiErrorResponse.of(exception.getApiErrorCode());
+	}
+
+	// Json 파싱 과정 중 에러가 났을때 처리하는 handler
+	// 참고 : https://be-student.tistory.com/52
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ApiErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
+		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception);
+		return ApiErrorResponse.INVALID_JSON_ERROR();
 	}
 }

--- a/backend/techpick-core/src/main/resources/application-core.yaml
+++ b/backend/techpick-core/src/main/resources/application-core.yaml
@@ -38,8 +38,6 @@ spring:
     username: ${DOCKER_MYSQL_USERNAME}
     password: ${DOCKER_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-core:
-  base-url: http://localhost:8080
 
 ---
 
@@ -59,8 +57,6 @@ spring:
     username: ${DOCKER_MYSQL_USERNAME}
     password: ${DOCKER_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-core:
-  base-url: https://v2.minlife.me
 
 ---
 
@@ -80,7 +76,5 @@ spring:
     username: ${DOCKER_MYSQL_USERNAME}
     password: ${DOCKER_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-core:
-  base-url: https://api.techpick.org
 
 ---

--- a/backend/techpick-security/src/main/java/techpick/security/config/SecurityConfig.java
+++ b/backend/techpick-security/src/main/java/techpick/security/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package techpick.security.config;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,10 +35,7 @@ public class SecurityConfig {
 	private final TokenAuthenticationFilter tokenAuthenticationFilter;
 	private final TechPickLogoutHandler techPickLogoutHandler;
 	private final TechPickAuthorizationRequestRepository requestRepository;
-	private final SecurityProperties securityProperties;
-	
-	@Value("${core.base-url}")
-	private String baseUrl;
+	private final SecurityProperties properties;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -89,8 +85,8 @@ public class SecurityConfig {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowCredentials(true);
-		config.setAllowedOrigins(List.of(baseUrl));
-		config.setAllowedOriginPatterns(securityProperties.getCorsPatterns());
+		config.setAllowedOrigins(List.of(properties.getBaseUrl()));
+		config.setAllowedOriginPatterns(properties.getCorsPatterns());
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setExposedHeaders(List.of("*"));

--- a/backend/techpick-security/src/main/java/techpick/security/config/SecurityProperties.java
+++ b/backend/techpick-security/src/main/java/techpick/security/config/SecurityProperties.java
@@ -24,4 +24,5 @@ public class SecurityProperties {
 
 	private final String defaultRedirectUrl;
 
+	private final String baseUrl;
 }

--- a/backend/techpick-security/src/main/java/techpick/security/util/CookieUtil.java
+++ b/backend/techpick-security/src/main/java/techpick/security/util/CookieUtil.java
@@ -50,7 +50,7 @@ public class CookieUtil {
 
 	/**
 	 * 쿠키 삭제를 위한 메소드
-	 *
+	 * 삭제하려는 쿠키를 덮어씌워 삭제함
 	 * @author Gyaak
 	 *
 	 * @param request
@@ -58,24 +58,7 @@ public class CookieUtil {
 	 * @param name 삭제하려는 쿠키 이름
 	 */
 	public void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
-		if (request == null || response == null) {
-			return;
-		}
-
-		Cookie[] requestCookies = request.getCookies();
-		if (requestCookies == null) {
-			return;
-		}
-
-		for (Cookie cookie : requestCookies) {
-			if (name.equals(cookie.getName())) {
-				cookie.setValue("");
-				cookie.setPath("/");
-				cookie.setMaxAge(0);
-				cookie.setHttpOnly(true);
-				response.addCookie(cookie);
-			}
-		}
+		this.addCookie(response, name, "", 0, true);
 	}
 
 	public Optional<String> findCookieValue(Cookie[] cookies, String name) {

--- a/backend/techpick-security/src/main/resources/application-security.yaml
+++ b/backend/techpick-security/src/main/resources/application-security.yaml
@@ -11,14 +11,12 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: ${TECHPICK_BASE_URL}/api/login/oauth2/code/google
             scope:
               - email
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
             client-name: Naver
-            redirect-uri: ${TECHPICK_BASE_URL}/api/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope:
               - email
@@ -26,7 +24,6 @@ spring:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-name: Kakao
-            redirect-uri: ${TECHPICK_BASE_URL}/api/login/oauth2/code/kakao
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:
@@ -61,12 +58,23 @@ spring:
   config:
     activate:
       on-profile: local
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: http://localhost:8080/api/login/oauth2/code/google
+          naver:
+            redirect-uri: http://localhost:8080/api/login/oauth2/code/naver
+          kakao:
+            redirect-uri: http://localhost:8080/api/login/oauth2/code/kakao
 security:
   cors-patterns:
     - chrome-extension://*
     - https://local.minlife.me:3000
   cookie-domain: localhost
   default-redirect-url: http://localhost:8080
+  base-url: http://localhost:8080
 
 ---
 
@@ -74,6 +82,16 @@ spring:
   config:
     activate:
       on-profile: dev
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: https://v2.minlife.me/api/login/oauth2/code/google
+          naver:
+            redirect-uri: https://v2.minlife.me/api/login/oauth2/code/naver
+          kakao:
+            redirect-uri: https://v2.minlife.me/api/login/oauth2/code/kakao
 security:
   cors-patterns:
     - chrome-extension://*
@@ -81,6 +99,7 @@ security:
     - https://local.minlife.me:3000
   cookie-domain: minlife.me
   default-redirect-url: https://local.minlife.me
+  base-url: https://v2.minlife.me
 
 ---
 
@@ -88,11 +107,22 @@ spring:
   config:
     activate:
       on-profile: prod
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: https://api.techpick.org/api/login/oauth2/code/google
+          naver:
+            redirect-uri: https://api.techpick.org/api/login/oauth2/code/naver
+          kakao:
+            redirect-uri: https://api.techpick.org/api/login/oauth2/code/kakao
 security:
   cors-patterns:
     - chrome-extension://*
     - https://*.techpick.org
   cookie-domain: techpick.org
   default-redirect-url: https://app.techpick.org
+  base-url: https://api.techpick.org
 
 ---


### PR DESCRIPTION
- Close #426 #390

## What is this PR? 🔍

- 기능 : 시큐리티 및 예외처리 리팩토링
- issue : #426 #390

## Changes 📝
---
# Cookie 삭제 메소드 리팩토링
### AS-IS
- request에서 삭제하려는 쿠키가 존재하는지 확인하여 maxAge를 0으로 변경

### TO-BE
- 삭제하려는 쿠키 이름으로 maxAge = 0인 쿠키를 덮어씌움

### Why
- request에 쿠키가 포함되어있지 않았다면 삭제가 안되는 문제 발생

# BASE_URL application-security로 이관
### AS-IS
- env에서 `TECHPICK_BASE_URL`을 주입받아 활용

### TO-BE
- 해당 base-url를 사용하는곳이 spring security관련 설정 뿐이라 application-security.yaml로 하드코딩 예정

### Why
- 해당 값은 local/dev/prod에서 모두 변경되어야하는 값인데 환경변수로 주입받으면 프로파일마다 따로 설정해야해서 관리가 번거로움

# JSON 파싱 관련 예외 추가
기존에는 Json 형식에 오류가 있어 파싱 실패시 500에러가 발생
-> 프론트에서 예외처리 하기 힘듬

- Json 파싱 실패 시 발생하는 HttpMessageNotReadableException을 처리할 수 있는 ExceptionHandler 추가
- INVALID_JSON_ERROR 추가

