### PR TITLE
[FIX] FolderService 로직 변경

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
@@ -19,12 +19,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import techpick.api.domain.folder.service.FolderService;
+import lombok.RequiredArgsConstructor;
 import techpick.api.application.folder.dto.FolderApiMapper;
 import techpick.api.application.folder.dto.FolderApiRequest;
 import techpick.api.application.folder.dto.FolderApiResponse;
+import techpick.api.domain.folder.service.FolderService;
 import techpick.security.annotation.LoginUserId;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -111,12 +111,27 @@ public class FolderApiController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@PatchMapping("/order")
+	@Operation(summary = "폴더 순서변경", description = "사용자가 등록한 폴더들의 순서를 변경합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "폴더 순서 변경 성공"),
+		@ApiResponse(responseCode = "400", description = "기본 폴더는 순서를 변경할 수 없습니다."),
+		@ApiResponse(responseCode = "401", description = "본인 폴더만 순서를 변경할 수 있습니다."),
+		@ApiResponse(responseCode = "406", description = "부모가 다른 폴더들을 동시에 순서를 변경할 수 없습니다.")
+	})
+	public ResponseEntity<Void> changeFolderOrder(@LoginUserId Long userId,
+		@Valid @RequestBody FolderApiRequest.Order request) {
+		folderService.changeFolderOrder(mapper.toOrderCommand(userId, request));
+		return ResponseEntity.noContent().build();
+	}
+
 	@PatchMapping("/location")
 	@Operation(summary = "폴더 이동", description = "사용자가 등록한 폴더를 이동합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "폴더 이동 성공"),
 		@ApiResponse(responseCode = "400", description = "기본 폴더는 이동할 수 없습니다."),
 		@ApiResponse(responseCode = "401", description = "본인 폴더만 이동할 수 있습니다."),
+		@ApiResponse(responseCode = "406", description = "미분류폴더, 휴지통 폴더로 이동할 수 없습니다."),
 		@ApiResponse(responseCode = "406", description = "부모가 다른 폴더들을 동시에 이동할 수 없습니다.")
 	})
 	public ResponseEntity<Void> moveFolder(@LoginUserId Long userId,

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderApiController.java
@@ -111,20 +111,6 @@ public class FolderApiController {
 		return ResponseEntity.noContent().build();
 	}
 
-	@PatchMapping("/order")
-	@Operation(summary = "폴더 순서변경", description = "사용자가 등록한 폴더들의 순서를 변경합니다.")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "204", description = "폴더 순서 변경 성공"),
-		@ApiResponse(responseCode = "400", description = "기본 폴더는 순서를 변경할 수 없습니다."),
-		@ApiResponse(responseCode = "401", description = "본인 폴더만 순서를 변경할 수 있습니다."),
-		@ApiResponse(responseCode = "406", description = "부모가 다른 폴더들을 동시에 순서를 변경할 수 없습니다.")
-	})
-	public ResponseEntity<Void> changeFolderOrder(@LoginUserId Long userId,
-		@Valid @RequestBody FolderApiRequest.Order request) {
-		folderService.changeFolderOrder(mapper.toOrderCommand(userId, request));
-		return ResponseEntity.noContent().build();
-	}
-
 	@PatchMapping("/location")
 	@Operation(summary = "폴더 이동", description = "사용자가 등록한 폴더를 이동합니다.")
 	@ApiResponses(value = {

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiMapper.java
@@ -21,8 +21,6 @@ public interface FolderApiMapper {
 
 	FolderCommand.Move toMoveCommand(Long userId, FolderApiRequest.Move request);
 
-	FolderCommand.Order toOrderCommand(Long userId, FolderApiRequest.Order request);
-
 	FolderCommand.Delete toDeleteCommand(Long userId, FolderApiRequest.Delete request);
 
 	FolderApiResponse toApiResponse(FolderResult result);

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiMapper.java
@@ -21,6 +21,8 @@ public interface FolderApiMapper {
 
 	FolderCommand.Move toMoveCommand(Long userId, FolderApiRequest.Move request);
 
+	FolderCommand.Order toOrderCommand(Long userId, FolderApiRequest.Order request);
+
 	FolderCommand.Delete toDeleteCommand(Long userId, FolderApiRequest.Delete request);
 
 	FolderApiResponse toApiResponse(FolderResult result);

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
@@ -28,13 +28,6 @@ public class FolderApiRequest {
 	) {
 	}
 
-	public record Order(
-		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList,
-		@Schema(example = "3") @NotNull Long parentFolderId,
-		@Schema(example = "2") int orderIdx
-	) {
-	}
-
 	public record Delete(
 		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList
 	) {

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
@@ -22,7 +22,15 @@ public class FolderApiRequest {
 
 	public record Move(
 		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList,
+		@Schema(example = "7") @NotNull Long parentFolderId,
 		@Schema(example = "3") @NotNull Long destinationFolderId,
+		@Schema(example = "2") int orderIdx
+	) {
+	}
+
+	public record Order(
+		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList,
+		@Schema(example = "3") @NotNull Long parentFolderId,
 		@Schema(example = "2") int orderIdx
 	) {
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderCommand.java
@@ -25,7 +25,16 @@ public class FolderCommand {
 	public record Move(
 		Long userId,
 		List<Long> idList,
+		Long parentFolderId,
 		Long destinationFolderId,
+		int orderIdx
+	) {
+	}
+
+	public record Order(
+		Long userId,
+		List<Long> idList,
+		Long parentFolderId,
 		int orderIdx
 	) {
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderErrorCode.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderErrorCode.java
@@ -26,6 +26,8 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 		("F0-006", HttpStatus.NOT_ACCEPTABLE, "기본 폴더는 1개만 존재할 수 있음.", ErrorLevel.MUST_NEVER_HAPPEN()),
 	INVALID_MOVE_TARGET
 		("F0-007", HttpStatus.NOT_ACCEPTABLE, "이동하려는 폴더들의 범위가 올바르지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
+	INVALID_PARENT_FOLDER
+		("FO-008", HttpStatus.NOT_ACCEPTABLE, "부모 폴더가 올바르지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	;
 
 	private final String code;

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderException.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderException.java
@@ -43,4 +43,8 @@ public class ApiFolderException extends ApiException {
 	public static ApiFolderException INVALID_MOVE_TARGET() {
 		return new ApiFolderException(ApiFolderErrorCode.INVALID_MOVE_TARGET);
 	}
+
+	public static ApiFolderException INVALID_PARENT_FOLDER() {
+		return new ApiFolderException(ApiFolderErrorCode.INVALID_PARENT_FOLDER);
+	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -100,26 +100,6 @@ public class FolderService {
 	}
 
 	/**
-	 * 같은 폴더 내에서 폴더들의 순서를 변경
-	 * 현재 폴더들의 부모가 같은지 검증합니다.
-	 * */
-	@Transactional
-	public void changeFolderOrder(FolderCommand.Order command) {
-		Folder parentFolder = folderDataHandler.getFolder(command.parentFolderId());
-		validateFolderAccess(command.userId(), parentFolder);
-
-		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());
-		for (Folder folder : folderList) {
-			validateFolderAccess(command.userId(), folder);
-			validateBasicFolderChange(folder);
-		}
-
-		validateParentFolder(folderList, command.parentFolderId());
-		folderDataHandler.moveFolderWithinParent(command);
-	}
-
-	/**
-	 * 다른 폴더로 폴더를 이동
 	 * 현재 폴더들의 부모가 같은지 검증합니다.
 	 * 이동하려는 폴더가 미분류폴더, 휴지통이 아닌지 검증합니다.
 	 * */
@@ -134,9 +114,13 @@ public class FolderService {
 			validateFolderAccess(command.userId(), folder);
 			validateBasicFolderChange(folder);
 		}
-		validateParentFolder(folderList, command.parentFolderId());
 
-		folderDataHandler.moveFolderToDifferentParent(command);
+		validateParentFolder(folderList, command.parentFolderId());
+		if (Objects.equals(command.parentFolderId(), command.destinationFolderId())) {
+			folderDataHandler.moveFolderWithinParent(command);
+		} else {
+			folderDataHandler.moveFolderToDifferentParent(command);
+		}
 	}
 
 	@Transactional

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -167,8 +167,7 @@ public class FolderService {
 			targetPickIdList.addAll(folder.getChildPickIdOrderedList());
 		}
 
-		Folder recycleBin = folderDataHandler.getRecycleBin(command.userId());
-		pickDataHandler.updateParentFolder(targetPickIdList, recycleBin);
+		pickDataHandler.movePickListToRecycleBin(command.userId(), targetPickIdList);
 		folderDataHandler.deleteFolderList(command);
 	}
 

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -1,8 +1,12 @@
 package techpick.api.domain.folder.service;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -15,6 +19,7 @@ import techpick.api.domain.folder.dto.FolderMapper;
 import techpick.api.domain.folder.dto.FolderResult;
 import techpick.api.domain.folder.exception.ApiFolderException;
 import techpick.api.infrastructure.folder.FolderDataHandler;
+import techpick.api.infrastructure.pick.PickDataHandler;
 import techpick.core.model.folder.Folder;
 import techpick.core.model.folder.FolderType;
 
@@ -24,6 +29,7 @@ public class FolderService {
 
 	private final FolderDataHandler folderDataHandler;
 	private final FolderMapper folderMapper;
+	private final PickDataHandler pickDataHandler;
 
 	@Transactional(readOnly = true)
 	public FolderResult getFolder(FolderCommand.Read command) {
@@ -47,6 +53,7 @@ public class FolderService {
 	}
 
 	// TODO: 현재는 1depth만 반환하고 있지만, 추후 ~3depth까지 반환할 예정
+	// Root 폴더를 받아야하는 이유가 있나..? 내일 승태님께 물어보기
 	@Transactional(readOnly = true)
 	public List<FolderResult> getAllRootFolderList(Long userId) {
 		Folder rootFolder = folderDataHandler.getRootFolder(userId);
@@ -75,6 +82,9 @@ public class FolderService {
 
 	@Transactional
 	public FolderResult saveFolder(FolderCommand.Create command) {
+		Folder parentFolder = folderDataHandler.getFolder(command.parentFolderId());
+		validateFolderAccess(command.userId(), parentFolder);
+
 		return folderMapper.toResult(folderDataHandler.saveFolder(command));
 	}
 
@@ -89,43 +99,77 @@ public class FolderService {
 		return folderMapper.toResult(folderDataHandler.updateFolder(command));
 	}
 
+	/**
+	 * 같은 폴더 내에서 폴더들의 순서를 변경
+	 * 현재 폴더들의 부모가 같은지 검증합니다.
+	 * */
 	@Transactional
-	public void moveFolder(FolderCommand.Move command) {
-		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());
+	public void changeFolderOrder(FolderCommand.Order command) {
+		Folder parentFolder = folderDataHandler.getFolder(command.parentFolderId());
+		validateFolderAccess(command.userId(), parentFolder);
 
+		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());
 		for (Folder folder : folderList) {
 			validateFolderAccess(command.userId(), folder);
 			validateBasicFolderChange(folder);
 		}
 
+		validateParentFolder(folderList, command.parentFolderId());
+		folderDataHandler.moveFolderWithinParent(command);
+	}
+
+	/**
+	 * 다른 폴더로 폴더를 이동
+	 * 현재 폴더들의 부모가 같은지 검증합니다.
+	 * 이동하려는 폴더가 미분류폴더, 휴지통이 아닌지 검증합니다.
+	 * */
+	@Transactional
+	public void moveFolder(FolderCommand.Move command) {
 		Folder destinationFolder = folderDataHandler.getFolder(command.destinationFolderId());
-		// TODO: 현재 프론트에서 같은 부모 폴더에서만 폴더들을 선택하여 이동할 수 있음.
-		//  추후 다른 부모 폴더도 선택이 가능해지게 된다면, get(0) 사용하는 방식이 아닌 다른 방식을 고려해야 함.
-		Long parentFolderId = folderList.get(0).getParentFolder().getId();
-		if (isParentFolderNotChanged(command, parentFolderId)) {
-			validateWithinParentFolder(folderList, destinationFolder);
-			folderDataHandler.moveFolderWithinParent(command);
-			return;
+		validateFolderAccess(command.userId(), destinationFolder);
+		validateDestinationFolder(destinationFolder);
+
+		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());
+		for (Folder folder : folderList) {
+			validateFolderAccess(command.userId(), folder);
+			validateBasicFolderChange(folder);
 		}
-		validateDifferentParentFolder(folderList, destinationFolder);
+		validateParentFolder(folderList, command.parentFolderId());
+
 		folderDataHandler.moveFolderToDifferentParent(command);
 	}
 
 	@Transactional
 	public void deleteFolder(FolderCommand.Delete command) {
-
-		List<Folder> folderList = folderDataHandler.getFolderList(command.idList());
-
-		for (Folder folder : folderList) {
+		// 휴지통으로 이동되어야할 픽 리스트
+		List<Long> targetPickIdList = new ArrayList<>();
+		// 삭제할 폴더 리스트
+		List<Folder> targetFolderList = folderDataHandler.getFolderList(command.idList());
+		for (Folder folder : targetFolderList) {
 			validateFolderAccess(command.userId(), folder);
 			validateBasicFolderChange(folder);
 		}
+		// db 재귀조회를 하지 않기위해 본인 폴더를 모두 가져와서 Map 형태로 들고있음.
+		// TODO: queryDSL을 사용해서 최적화 할 수 있으면 좋을거같음.
+		Map<Long, Folder> folderMap = folderDataHandler.getFolderListByUserId(command.userId())
+			.stream()
+			.collect(Collectors.toMap(Folder::getId, folder -> folder));
 
+		// BFS로 자식폴더들을 순회하며 삭제할 폴더 리스트와 휴지통으로 보낼 픽 리스트를 얻음
+		Queue<Folder> queue = new ArrayDeque<>(targetFolderList);
+		while (!queue.isEmpty()) {
+			Folder folder = queue.poll();
+			for (Long childFolderId : folder.getChildFolderIdOrderedList()) {
+				Folder childFolder = folderMap.get(childFolderId);
+				targetFolderList.add(childFolder);
+				queue.add(childFolder);
+			}
+			targetPickIdList.addAll(folder.getChildPickIdOrderedList());
+		}
+
+		Folder recycleBin = folderDataHandler.getRecycleBin(command.userId());
+		pickDataHandler.updateParentFolder(targetPickIdList, recycleBin);
 		folderDataHandler.deleteFolderList(command);
-	}
-
-	private boolean isParentFolderNotChanged(FolderCommand.Move command, Long parentFolderId) {
-		return (command.destinationFolderId() == null || parentFolderId.equals(command.destinationFolderId()));
 	}
 
 	private void validateFolderAccess(Long userId, Folder folder) {
@@ -140,27 +184,28 @@ public class FolderService {
 		}
 	}
 
-	private void validateWithinParentFolder(List<Folder> folderList, Folder destinationFolder) {
+	/**
+	 * 같은 폴더 내에서 순서를 변경하는 경우에 검증로직입니다.
+	 * 이동하려는 폴더들의 부모가 실제 부모폴더와 일치하는지 검증합니다.
+	 * */
+	private void validateParentFolder(List<Folder> folderList, Long parentFolderId) {
 		for (Folder folder : folderList) {
 			Folder parentFolder = folder.getParentFolder();
-			if (Objects.equals(destinationFolder.getFolderType(), FolderType.UNCLASSIFIED)) {
-				throw ApiFolderException.FOLDER_ACCESS_DENIED();
-			}
-			if (ObjectUtils.notEqual(parentFolder.getId(), destinationFolder.getId())) {
-				throw ApiFolderException.INVALID_MOVE_TARGET();
+			if (ObjectUtils.notEqual(parentFolder.getId(), parentFolderId)) {
+				throw ApiFolderException.INVALID_PARENT_FOLDER();
 			}
 		}
 	}
 
-	private void validateDifferentParentFolder(List<Folder> folderList, Folder destinationFolder) {
-		for (Folder folder : folderList) {
-			Folder parentFolder = folder.getParentFolder();
-			if (Objects.equals(destinationFolder.getFolderType(), FolderType.UNCLASSIFIED)) {
-				throw ApiFolderException.FOLDER_ACCESS_DENIED();
-			}
-			if (Objects.equals(parentFolder.getId(), destinationFolder.getId())) {
-				throw ApiFolderException.INVALID_MOVE_TARGET();
-			}
+	/**
+	 * 폴더 이동시 미분류폴더, 휴지통으로는 이동할 수 없습니다.
+	 * */
+	private void validateDestinationFolder(Folder destinationFolder) {
+		if (Objects.equals(destinationFolder.getFolderType(), FolderType.UNCLASSIFIED)) {
+			throw ApiFolderException.INVALID_MOVE_TARGET();
+		}
+		if (Objects.equals(destinationFolder.getFolderType(), FolderType.RECYCLE_BIN)) {
+			throw ApiFolderException.INVALID_MOVE_TARGET();
 		}
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -83,7 +83,7 @@ public class FolderDataHandler {
 	}
 
 	@Transactional
-	public List<Long> moveFolderWithinParent(FolderCommand.Order command) {
+	public List<Long> moveFolderWithinParent(FolderCommand.Move command) {
 		Folder parentFolder = folderRepository.findById(command.parentFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -43,6 +43,11 @@ public class FolderDataHandler {
 	}
 
 	@Transactional(readOnly = true)
+	public List<Folder> getFolderListByUserId(Long userId) {
+		return folderRepository.findByUserId(userId);
+	}
+
+	@Transactional(readOnly = true)
 	public Folder getRootFolder(Long userId) {
 		return folderRepository.findRootByUserId(userId);
 	}
@@ -78,13 +83,12 @@ public class FolderDataHandler {
 	}
 
 	@Transactional
-	public List<Long> moveFolderWithinParent(FolderCommand.Move command) {
-		Long destinationFolderId = command.destinationFolderId();
-		Folder destinationFolder = folderRepository.findById(destinationFolderId)
+	public List<Long> moveFolderWithinParent(FolderCommand.Order command) {
+		Folder parentFolder = folderRepository.findById(command.parentFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
-		destinationFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
-		return destinationFolder.getChildFolderIdOrderedList();
+		parentFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
+		return parentFolder.getChildFolderIdOrderedList();
 	}
 
 	@Transactional

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -114,6 +114,18 @@ public class PickDataHandler {
 		return pick;
 	}
 
+	/**
+	 * 폴더 삭제시 안에있는 픽들의 부모를 일괄로 휴지통폴더로 업데이트 하기 위함
+	 * */
+	@Transactional
+	public void updateParentFolder(List<Long> pickIdList, Folder parentFolder) {
+		List<Pick> pickList = pickRepository.findAllById(pickIdList);
+
+		pickList.forEach(pick -> pick.updateParentFolder(parentFolder));
+
+		pickRepository.saveAll(pickList);
+	}
+
 	@Transactional
 	public void movePickToCurrentFolder(PickCommand.Move command) {
 		List<Long> pickIdList = command.idList();

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -114,18 +114,6 @@ public class PickDataHandler {
 		return pick;
 	}
 
-	/**
-	 * 폴더 삭제시 안에있는 픽들의 부모를 일괄로 휴지통폴더로 업데이트 하기 위함
-	 * */
-	@Transactional
-	public void updateParentFolder(List<Long> pickIdList, Folder parentFolder) {
-		List<Pick> pickList = pickRepository.findAllById(pickIdList);
-
-		pickList.forEach(pick -> pick.updateParentFolder(parentFolder));
-
-		pickRepository.saveAll(pickList);
-	}
-
 	@Transactional
 	public void movePickToCurrentFolder(PickCommand.Move command) {
 		List<Long> pickIdList = command.idList();
@@ -146,6 +134,17 @@ public class PickDataHandler {
 			pick.getParentFolder().removeChildPickOrder(pickId);
 			pick.updateParentFolder(destinationFolder);
 		}
+	}
+
+	@Transactional
+	public void movePickListToRecycleBin(Long userId, List<Long> pickIdList) {
+		// 휴지통에 픽 추가
+		Folder recycleBin = folderRepository.findRecycleBinByUserId(userId);
+		recycleBin.getChildPickIdOrderedList().addAll(0, pickIdList);
+
+		// 픽들의 부모를 휴지통으로 변경
+		List<Pick> pickList = pickRepository.findAllById(pickIdList);
+		pickList.forEach(pick -> pick.updateParentFolder(recycleBin));
 	}
 
 	@Transactional

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
+	List<Folder> findByUserId(Long userId);
+	
 	List<Folder> findByParentFolderId(Long parentFolderId);
 
 	// TODO: QueryDSL 도입 후 리팩토링 필요

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
@@ -3,9 +3,6 @@ package techpick.core.model.pick;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -56,9 +53,7 @@ public class Pick extends BaseEntity {
 	@JoinColumn(name = "link_id", nullable = false)
 	private Link link;
 
-	// 부모 폴더가 삭제되면 자식픽 또한 삭제됨, OnDelete 옵션을 위해 FK필요
 	@ManyToOne(fetch = FetchType.LAZY)
-	@OnDelete(action = OnDeleteAction.CASCADE)
 	@JoinColumn(name = "parent_folder_id", nullable = false)
 	private Folder parentFolder;
 


### PR DESCRIPTION
- Close #431

## What is this PR? 🔍

- 기능 : FolderService 로직 변경
- issue : #431 

## Changes 📝

### `FolderService` 검증 로직 추가
`saveFolder` : 부모 폴더가 본인 소유인지 검증하는 로직 추가
`moveFolder` : 이동하려는 폴더들의 부모폴더가 동일한지 검증하는 로직 추가

### 폴더 이동 관련 dto 필드 추가
폴더 이동 시 이동하는 폴더들의 parentFolderId를 같이 보내줘야합니다. @dmdgpdi 
```
public record Move(
  Long userId,
  List<Long> idList,
  Long parentFolderId, // 추가됨
  Long destinationFolderId,
  int orderIdx
  ) {
}
```

### 폴더 삭제 로직 변경
기존 : 폴더 삭제 시 모든 하위폴더와 픽들이 삭제됨
변경 : 폴더 삭제 시 모든 하위폴더는 삭제되고 픽들은 휴지통으로 이동됨

