### PR TITLE
[FIX] DragOver 수정 및 휴지통 이동 로직 변경

### DIFF
--- a/frontend/schema/schema.d.ts
+++ b/frontend/schema/schema.d.ts
@@ -411,6 +411,11 @@ export interface components {
             idList: number[];
             /**
              * Format: int64
+             * @example 7
+             */
+            parentFolderId: number;
+            /**
+             * Format: int64
              * @example 3
              */
             destinationFolderId: number;
@@ -945,7 +950,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description 부모가 다른 폴더들을 동시에 이동할 수 없습니다. */
+            /** @description 미분류폴더, 휴지통 폴더로 이동할 수 없습니다. */
             406: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/techpick/src/apis/folder/deleteFolder.ts
+++ b/frontend/techpick/src/apis/folder/deleteFolder.ts
@@ -7,8 +7,8 @@ export const deleteFolder = async (
   deleteFolderList: DeleteFolderRequestType['idList']
 ) => {
   try {
-    await apiClient.delete<DeleteFolderRequestType>(API_URLS.DELETE_FOLDER, {
-      json: deleteFolderList,
+    await apiClient.delete(API_URLS.DELETE_FOLDER, {
+      json: { idList: deleteFolderList },
     });
 
     return;

--- a/frontend/techpick/src/components/DragOverlay.tsx
+++ b/frontend/techpick/src/components/DragOverlay.tsx
@@ -1,18 +1,80 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { DragOverlay as DndKitDragOverlay } from '@dnd-kit/core';
 import { usePickStore, useTreeStore } from '@/stores';
-import { pickDragOverlayStyle, scaledDownStyle } from './dragOverlay.css';
+import { pickDragOverlayStyle } from './dragOverlay.css';
 import { PickCard } from './PickListViewer/PickCard';
 
-export function DargOverlay() {
+export function DargOverlay({ elementClickPosition }: DargOverlayProps) {
   const { isDragging: isFolderDragging, draggingFolderInfo } = useTreeStore();
   const { isDragging: isPickDragging, draggingPickInfo } = usePickStore();
+  const [mousePosition, setMousePosition] = useState({ x: -1, y: -1 });
+  const overlayStyle: CSSProperties = {
+    top: `${mousePosition.y}px`,
+    left: `${mousePosition.x}px`,
+    transform: 'translate3d(0, 0, 0)', // translate3d를 none으로 설정
+    pointerEvents: 'none', // 오버레이가 마우스 이벤트를 방해하지 않도록 설정
+  };
+
+  useEffect(
+    function trackingMousePointer() {
+      const handleMouseMove = (event: MouseEvent | TouchEvent) => {
+        if (!(isPickDragging || isFolderDragging)) {
+          return;
+        }
+
+        const clientX =
+          event instanceof MouseEvent
+            ? event.clientX
+            : event.touches[0].clientX;
+        const clientY =
+          event instanceof MouseEvent
+            ? event.clientY
+            : event.touches[0].clientY;
+
+        if (isPickDragging) {
+          setMousePosition({
+            x: clientX - elementClickPosition.x,
+            y: clientY - elementClickPosition.y,
+          });
+
+          return;
+        }
+
+        if (isFolderDragging) {
+          setMousePosition({
+            x: clientX - elementClickPosition.x,
+            y: clientY - elementClickPosition.y,
+          });
+        }
+      };
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('touchmove', handleMouseMove);
+
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('touchmove', handleMouseMove);
+      };
+    },
+    [
+      elementClickPosition.x,
+      elementClickPosition.y,
+      isFolderDragging,
+      isPickDragging,
+    ]
+  );
+
+  if (mousePosition.x === -1 && mousePosition.y === -1) {
+    return;
+  }
 
   if (isPickDragging && draggingPickInfo) {
     return (
-      <DndKitDragOverlay>
-        <div className={scaledDownStyle}>
+      <DndKitDragOverlay style={overlayStyle}>
+        <div>
           <PickCard pickInfo={draggingPickInfo}></PickCard>
         </div>
       </DndKitDragOverlay>
@@ -21,7 +83,7 @@ export function DargOverlay() {
 
   if (isFolderDragging && draggingFolderInfo) {
     return (
-      <DndKitDragOverlay>
+      <DndKitDragOverlay style={overlayStyle}>
         <div className={`${pickDragOverlayStyle}`}>
           {draggingFolderInfo.name}
         </div>
@@ -30,4 +92,11 @@ export function DargOverlay() {
   }
 
   return null;
+}
+
+interface DargOverlayProps {
+  elementClickPosition: {
+    x: number;
+    y: number;
+  };
 }

--- a/frontend/techpick/src/components/FolderAndPickDndContextProvider.tsx
+++ b/frontend/techpick/src/components/FolderAndPickDndContextProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import type { PropsWithChildren } from 'react';
 import { DndContext, pointerWithin } from '@dnd-kit/core';
 import { useGetDndContextSensor } from '@/hooks';
@@ -12,22 +13,18 @@ import { DargOverlay } from './DragOverlay';
 export function FolderAndPickDndContextProvider({
   children,
 }: PropsWithChildren) {
-  const { sensors } = useGetDndContextSensor();
+  const [elementClickPosition, setElementClickPosition] = useState({
+    x: 0,
+    y: 0,
+  });
+  const { sensors } = useGetDndContextSensor({
+    setElementClickPosition,
+  });
 
   return (
     <DndContext sensors={sensors} collisionDetection={pointerWithin}>
       <DndMonitorContext>{children}</DndMonitorContext>
-      <DargOverlay />
+      <DargOverlay elementClickPosition={elementClickPosition} />
     </DndContext>
   );
-}
-
-/**
- * @description FolderTreeDragOverlay
- */
-{
-  /* <DragOverlay>
-
-<div className={`${dragOverStyle}`}>Drag 한 폴더의 이름</div>
-</DragOverlay> */
 }

--- a/frontend/techpick/src/components/FolderTree/FolderDraggable.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderDraggable.tsx
@@ -22,7 +22,7 @@ export const FolderDraggable = ({
       type: 'folder',
     },
   });
-
+  const folderElementId = `folderId-${id}`;
   const isSelected = selectedFolderList.includes(id);
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
@@ -46,7 +46,13 @@ export const FolderDraggable = ({
   }
 
   return (
-    <div ref={setNodeRef} {...attributes} {...listeners} style={style}>
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      style={style}
+      id={folderElementId}
+    >
       {children}
     </div>
   );

--- a/frontend/techpick/src/components/PickListViewer/PickDnDCard.tsx
+++ b/frontend/techpick/src/components/PickListViewer/PickDnDCard.tsx
@@ -49,6 +49,7 @@ export function PickDnDCard({ pickInfo }: PickViewDnDItemComponentProps) {
       parentFolderId: parentFolderId,
     },
   });
+  const pickElementId = `pickId-${pickId}`;
 
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
@@ -100,6 +101,7 @@ export function PickDnDCard({ pickInfo }: PickViewDnDItemComponentProps) {
         className={`${pickCardLayout} ${isSelected ? selectedDragItemStyle : ''} ${isActiveDragging ? isActiveDraggingItemStyle : ''}`}
         onDoubleClick={openUrl}
         onClick={(event) => handleClick(pickId, event)}
+        id={pickElementId}
       >
         <div className={cardImageSectionStyle}>
           {imageUrl ? (

--- a/frontend/techpick/src/components/dragOverlay.css.ts
+++ b/frontend/techpick/src/components/dragOverlay.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { colorThemeContract } from 'techpick-shared';
 
 export const pickDragOverlayStyle = style({
-  minWidth: '200px',
+  width: '200px',
   minHeight: '30px',
   padding: '8px 12px',
   margin: '4px 0',
@@ -11,6 +11,9 @@ export const pickDragOverlayStyle = style({
   backgroundColor: '#fff',
   cursor: 'grab',
   transition: 'background-color 0.2s',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
   selectors: {
     '&:hover': {
       backgroundColor: colorThemeContract.primaryFaded,

--- a/frontend/techpick/src/hooks/useGetDndContextSensor.ts
+++ b/frontend/techpick/src/hooks/useGetDndContextSensor.ts
@@ -1,9 +1,43 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
 
-export function useGetDndContextSensor() {
+export function useGetDndContextSensor({
+  setElementClickPosition,
+}: UseGetDndContextSensorProps) {
+  const onActivation = (event: MouseEvent | TouchEvent) => {
+    let targetElement = event.target as HTMLElement | null;
+
+    while (
+      targetElement &&
+      !targetElement.id.includes('folder') &&
+      !targetElement.id.includes('pick')
+    ) {
+      targetElement = targetElement.parentElement;
+    }
+
+    if (!(targetElement && 'getBoundingClientRect' in targetElement)) {
+      return;
+    }
+
+    const rect = targetElement.getBoundingClientRect();
+
+    const clientX =
+      event instanceof MouseEvent ? event.clientX : event.touches[0].clientX;
+    const clientY =
+      event instanceof MouseEvent ? event.clientY : event.touches[0].clientY;
+
+    setElementClickPosition({
+      x: clientX - rect.left,
+      y: clientY - rect.top,
+    });
+  };
+
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: {
       distance: 10, // MouseSensor: 10px 이동해야 드래그 시작
+    },
+    onActivation({ event }: { event: MouseEvent | TouchEvent }) {
+      onActivation(event);
     },
   });
   const touchSensor = useSensor(TouchSensor, {
@@ -11,8 +45,20 @@ export function useGetDndContextSensor() {
       delay: 250,
       tolerance: 5,
     },
+    onActivation({ event }: { event: MouseEvent | TouchEvent }) {
+      onActivation(event);
+    },
   });
   const sensors = useSensors(mouseSensor, touchSensor);
 
   return { sensors };
+}
+
+interface UseGetDndContextSensorProps {
+  setElementClickPosition: Dispatch<
+    SetStateAction<{
+      x: number;
+      y: number;
+    }>
+  >;
 }

--- a/frontend/techpick/src/hooks/usePickToPickDndMonitor.tsx
+++ b/frontend/techpick/src/hooks/usePickToPickDndMonitor.tsx
@@ -22,6 +22,7 @@ export function usePickToPickDndMonitor() {
 
   const onDragStart = (event: DragStartEvent) => {
     const { active } = event;
+
     const activeObject = active.data.current;
 
     if (!isPickDraggableObject(activeObject)) return;
@@ -29,6 +30,7 @@ export function usePickToPickDndMonitor() {
     const pickId = Number(activeObject.id);
     const parentFolderId = activeObject.parentFolderId;
     const pickInfo = getPickInfoByFolderIdAndPickId(parentFolderId, pickId);
+    setFocusedPickId(pickId);
     setIsDragging(true);
     setDraggingPickInfo(pickInfo);
 
@@ -36,8 +38,6 @@ export function usePickToPickDndMonitor() {
       selectSinglePick(pickId);
       return;
     }
-
-    setFocusedPickId(pickId);
   };
 
   const onDragEnd = (event: DragEndEvent) => {

--- a/frontend/techpick/src/stores/dndTreeStore/dndTreeStore.ts
+++ b/frontend/techpick/src/stores/dndTreeStore/dndTreeStore.ts
@@ -5,6 +5,7 @@ import {
   getFolders,
   getBasicFolders,
   moveFolder,
+  deleteFolder,
   updateFolder,
   createFolder,
 } from '@/apis/folder';
@@ -247,6 +248,7 @@ export const useTreeStore = create<TreeState & TreeAction>()(
               idList: selectedFolderList,
               orderIdx: toData.sortable.index,
               destinationFolderId: Number(toData.sortable.containerId),
+              parentFolderId: Number(fromData.sortable.containerId),
             });
           } catch {
             set((state) => {
@@ -283,11 +285,16 @@ export const useTreeStore = create<TreeState & TreeAction>()(
           });
         });
       },
+      /**
+       * @description 나중에 dfs로 휴지통으로 픽들 이동.
+       */
       moveFolderToRecycleBin: async ({ deleteFolderId }) => {
         let parentFolderId = UNKNOWN_FOLDER_ID;
         let prevChildFolderList: ChildFolderListType = [];
-        const FIRST = 0;
-        let recycleBinFolderId = UNKNOWN_FOLDER_ID;
+        /**
+         * @description - 나중에 dfs로 휴지통으로 픽들 이동
+         */
+        // let recycleBinFolderId = UNKNOWN_FOLDER_ID;
 
         set((state) => {
           parentFolderId = state.treeDataMap[deleteFolderId].parentFolderId;
@@ -299,18 +306,14 @@ export const useTreeStore = create<TreeState & TreeAction>()(
           prevChildFolderList = [...childFolderList];
         });
 
-        set((state) => {
-          if (state.basicFolderMap) {
-            recycleBinFolderId = state.basicFolderMap['RECYCLE_BIN'].id;
-          }
-        });
+        // set((state) => {
+        //   if (state.basicFolderMap) {
+        //     recycleBinFolderId = state.basicFolderMap['RECYCLE_BIN'].id;
+        //   }
+        // });
 
         try {
-          await moveFolder({
-            idList: [deleteFolderId],
-            orderIdx: FIRST,
-            destinationFolderId: recycleBinFolderId,
-          });
+          await deleteFolder([deleteFolderId]);
         } catch {
           set((state) => {
             state.treeDataMap[parentFolderId].childFolderIdOrderedList =

--- a/frontend/techpick/src/utils/getElementById.ts
+++ b/frontend/techpick/src/utils/getElementById.ts
@@ -1,0 +1,8 @@
+export const getElementById = (id: string) => {
+  const element = document.querySelector(`#${id}`);
+
+  if (!element) {
+    throw new Error(`can not found ${id} element`);
+  }
+  return element;
+};

--- a/frontend/techpick/src/utils/index.ts
+++ b/frontend/techpick/src/utils/index.ts
@@ -9,3 +9,4 @@ export { isSelectionActive } from './dnd/isSelectionActive';
 export { isFolderDraggableObject } from './isFolderDraggableObject';
 export { isPickDraggableObject } from './isPickDraggableObjectType';
 export { isPickToFolderDroppableObject } from './isPickToFolderDroppableObject';
+export { getElementById } from './getElementById';


### PR DESCRIPTION
- Close #441


## What is this PR? 🔍

- 기능 :
- issue : #441

## Changes 📝
- 폴더 삭제 시에 폴더 이동api를 사용하는 것이 아닌 폴더 삭제 api를 사용합니다.
- 이전과 달리 multi-select 시에 첫번째 요소가 아닌 다른 요소를 드래그해도 자연스럽게 드래그 됩니다.

### before
https://github.com/user-attachments/assets/93d59251-5959-4124-9de9-33507a27fa7f
### after
https://github.com/user-attachments/assets/864f0616-1fcb-4665-81e5-ea5ec989cd8b


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
