### PR TITLE
[FIX] 현재 포커스된 폴더 삭제 시에 미분류 페이지로 리다이렉트

### DIFF
--- a/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import { useState } from 'react';
 import type { MouseEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { ROUTES } from '@/constants';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
 import { isSelectionActive } from '@/utils';
@@ -13,6 +16,8 @@ import {
 import type { FolderMapType } from '@/types';
 
 export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
+  const { folderId: urlFolderId } = useParams<{ folderId: string }>();
+  const router = useRouter();
   const {
     treeDataMap,
     selectedFolderList,
@@ -71,6 +76,10 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
       }}
       deleteFolder={() => {
         moveFolderToRecycleBin({ deleteFolderId: id });
+
+        if (Number(urlFolderId) === id) {
+          router.push(ROUTES.FOLDERS_UNCLASSIFIED);
+        }
       }}
       onShow={() => {
         selectSingleFolder(id);

--- a/frontend/techpick/src/styles/reset.css.ts
+++ b/frontend/techpick/src/styles/reset.css.ts
@@ -82,3 +82,7 @@ globalStyle('hr', {
   outline: 'none',
   margin: 0,
 });
+
+globalStyle('*', {
+  outline: 'none',
+});


### PR DESCRIPTION
- Close #445 

## What is this PR? 🔍

- 기능 :
- issue : #445 

## Changes 📝
- 포커스된 폴더를 삭제 시에 미분류 페이지로 리다이렉트 됩니다.
<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
