### PR TITLE
fix: 로그인 이후 뒤로가기 시 로그인 화면으로 이동하지 못하게 수정

### DIFF
--- a/frontend/techpick/src/app/(unsigned)/login/layout.tsx
+++ b/frontend/techpick/src/app/(unsigned)/login/layout.tsx
@@ -1,0 +1,16 @@
+'use server';
+
+import type { PropsWithChildren } from 'react';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ROUTES } from '@/constants';
+
+export default async function LoginPageLayout({ children }: PropsWithChildren) {
+  const authToken = cookies().get('access_token');
+
+  if (authToken) {
+    redirect(ROUTES.HOME);
+  }
+
+  return children;
+}


### PR DESCRIPTION
- Close #452 

## What is this PR? 🔍

- 기능 :
- issue : #452 

## Changes 📝
- 로그인 이후 뒤로가기로 로그인 페이지에 이동하는 동작을 막았습니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
