### PR TITLE
[FIX] 픽 수정 리팩토링 및 검증로직 개선

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
@@ -24,6 +24,7 @@ public class PickApiRequest {
 	public record Update(
 		@Schema(example = "1") @NotNull Long id,
 		@Schema(example = "Record란 뭘까?") String title,
+		@Schema(example = "3") Long parentFolderId,
 		@Schema(example = "[4, 5, 2, 1]") List<Long> tagIdOrderedList
 	) {
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
@@ -20,7 +20,7 @@ public class PickCommand {
 						 LinkInfo linkInfo) {
 	}
 
-	public record Update(Long userId, Long id, String title, List<Long> tagIdOrderedList) {
+	public record Update(Long userId, Long id, String title, Long parentFolderId, List<Long> tagIdOrderedList) {
 	}
 
 	public record Move(Long userId, List<Long> idList, Long destinationFolderId, int orderIdx) {

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -31,13 +31,22 @@ public class FolderDataHandler {
 	// idList에 포함된 모든 ID에 해당하는 폴더 리스트 조회, 순서를 보장하지 않음
 	@Transactional(readOnly = true)
 	public List<Folder> getFolderList(List<Long> idList) {
-		return folderRepository.findAllById(idList);
+		List<Folder> folderList = folderRepository.findAllById(idList);
+		// 조회리스트에 존재하지 않는 태그id가 존재하면 예외 발생
+		if (folderList.size() != idList.size()) {
+			throw ApiFolderException.FOLDER_NOT_FOUND();
+		}
+		return folderList;
 	}
 
 	// idList에 포함된 모든 ID에 해당하는 폴더 리스트 조회, 순서는 idList의 순서를 따름
 	@Transactional(readOnly = true)
 	public List<Folder> getFolderListPreservingOrder(List<Long> idList) {
-		var folderList = folderRepository.findAllById(idList);
+		List<Folder> folderList = folderRepository.findAllById(idList);
+		// 조회리스트에 존재하지 않는 태그id가 존재하면 예외 발생
+		if (folderList.size() != idList.size()) {
+			throw ApiFolderException.FOLDER_NOT_FOUND();
+		}
 		folderList.sort(Comparator.comparing(folder -> idList.indexOf(folder.getId())));
 		return folderList;
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
@@ -6,8 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import techpick.api.domain.tag.dto.TagCommand;
 import techpick.api.domain.tag.dto.TagMapper;
 import techpick.api.domain.tag.exception.ApiTagException;
@@ -47,7 +47,12 @@ public class TagDataHandler {
 
 	@Transactional(readOnly = true)
 	public List<Tag> getTagList(List<Long> tagOrderList) {
-		return tagRepository.findAllById(tagOrderList);
+		List<Tag> tagList = tagRepository.findAllById(tagOrderList);
+		// 조회리스트에 존재하지 않는 태그id가 존재하면 예외 발생
+		if (tagList.size() != tagOrderList.size()) {
+			throw ApiTagException.TAG_NOT_FOUND();
+		}
+		return tagList;
 	}
 
 	@Transactional

--- a/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickServiceTest.java
+++ b/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickServiceTest.java
@@ -286,7 +286,7 @@ class PickServiceTest {
 			String newTitle = "NEW_PICK";
 			List<Long> newTagOrder = List.of(tag3.getId(), tag2.getId(), tag1.getId());
 			PickCommand.Update updateCommand = new PickCommand.Update(
-				user.getId(), savePick.id(), newTitle, newTagOrder
+				user.getId(), savePick.id(), newTitle, null, newTagOrder
 			);
 			PickResult.Pick updatePick = pickService.updatePick(updateCommand);
 
@@ -423,8 +423,7 @@ class PickServiceTest {
 
 		@Test
 		@DisplayName("""
-			    1. 순서 설정값이 음수가 들어오면 예외를 발생시킨다.
-			    2. 순서 설정값이 전체 길이보다 큰 값이 들어오면 예외를 발생시킨다.
+			    순서 id 리스트가 존재하지 않는 픽 Id면 ApiPickException.PICK_NOT_FOUND() 예외를 발생시킨다.
 			""")
 		void move_pick_invalid_order_value_test() {
 			// given
@@ -440,7 +439,7 @@ class PickServiceTest {
 
 			// when, then
 			assertThatThrownBy(() -> pickService.movePick(command))
-				.isInstanceOf(IndexOutOfBoundsException.class);
+				.isInstanceOf(ApiPickException.class);
 		}
 	}
 

--- a/backend/techpick-api/src/test/java/techpick/api/fixture/PickFixture.java
+++ b/backend/techpick-api/src/test/java/techpick/api/fixture/PickFixture.java
@@ -26,7 +26,7 @@ public class PickFixture {
 
 	private Folder parentFolder;
 
-	private String title = "";
+	private String title;
 
 	private List<Long> tagIdOrderedList;
 


### PR DESCRIPTION
- Close #472

## What is this PR? 🔍

- 기능 : 픽 수정 리팩토링 및 검증로직 개선
- issue : #472

## Changes 📝

### id리스트로 조회시, 존재하지 않는 id에 대한 검증이 누락되어 추가함
- `TagDataHandler`
  - `getTagList`
- `PickDataHandler`
  - `getPickList`
  - `getPickListPreservingOrder`
- `FolderDataHandler`
  - `getFolderList`
  - `getFolderListPreservingOrder`

### Pick Update Refactoring
- 부모 폴더 수정 가능하도록 dto에 `parentFolderId` 필드 추가
- 필드가 존재하지 않는 경우(`null`) 수정하지 않도록 기능 변경

