### PR TITLE
[FEAT] 에러 요청에 대한 로깅 구현

### DIFF
--- a/backend/techpick-api/src/main/resources/logback-spring.xml
+++ b/backend/techpick-api/src/main/resources/logback-spring.xml
@@ -53,7 +53,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <!-- each archived file, size max 10MB -->
-                <maxFileSize>100MB</maxFileSize>
+                <maxFileSize>10MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <fileNamePattern>${LOG_PATH}/${DATE_DIR}/sql.%i.log</fileNamePattern>
             <!-- total size of all archive files, if total size > 20GB, it will delete old archived file -->
@@ -71,22 +71,19 @@
     <!-- "additivity=false"를 하면 해당 <logger>에서만 로깅 되고, 다른 곳으로 전달 되지 않는다.
         (ref: https://mkyong.com/logging/logback-duplicate-log-messages/) -->
 
-    <!--    &lt;!&ndash; (1) 프로젝트 전체 로그 설정  &ndash;&gt;-->
-    <!--    <logger name="techpick.api" level="debug" additivity="false">-->
-    <!--        <appender-ref ref="CONSOLE"/>-->
-    <!--        <appender-ref ref="APP-LOG-FILE"/>-->
-    <!--    </logger>-->
-
-    <!--    &lt;!&ndash; (2) SQL문 출력은 p6spy를 통해 콘솔 로만 출력 합니다. (파일 저장 X)  &ndash;&gt;-->
-    <!--    <logger name="p6spy" level="info" additivity="false">-->
-    <!--        <appender-ref ref="SQL-LOG-FILE"/>-->
-    <!--    </logger>-->
-
-    <!-- (3) root info 레벨은 파일과 콘솔에 모두 출력 합니다. -->
-    <root level="info">
+    <!-- (1) 프로젝트 전체 로그 설정  -->
+    <logger name="techpick.api" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
+    <logger name="techpick.core" level="info" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
+
+    <logger name="p6spy" level="info" additivity="false">
         <appender-ref ref="SQL-LOG-FILE"/>
-    </root>
+    </logger>
+
 
 </configuration>

--- a/backend/techpick-batch/src/main/resources/logback-spring.xml
+++ b/backend/techpick-batch/src/main/resources/logback-spring.xml
@@ -64,7 +64,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <!-- each archived file, size max 10MB -->
-                <maxFileSize>100MB</maxFileSize>
+                <maxFileSize>10MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <fileNamePattern>${LOG_PATH}/${DATE_DIR}/sql.%i.log</fileNamePattern>
             <!-- total size of all archive files, if total size > 20GB, it will delete old archived file -->
@@ -82,28 +82,19 @@
     <!-- "additivity=false"를 하면 해당 <logger>에서만 로깅 되고, 다른 곳으로 전달 되지 않는다.
         (ref: https://mkyong.com/logging/logback-duplicate-log-messages/) -->
 
-    <!--    &lt;!&ndash; (1) 프로젝트 전체 로그 설정  &ndash;&gt;-->
-    <!--    <logger name="techpick.api.batch" level="debug" additivity="false">-->
-    <!--        <appender-ref ref="CONSOLE"/>-->
-    <!--        <appender-ref ref="APP-LOG-FILE"/>-->
-    <!--    </logger>-->
-
-    <!--    <logger name="k.techpick.core" level="debug" additivity="false">-->
-    <!--        <appender-ref ref="CONSOLE"/>-->
-    <!--        <appender-ref ref="APP-LOG-FILE"/>-->
-    <!--    </logger>-->
-
-    <!--    &lt;!&ndash; (2) SQL문 출력은 p6spy를 통해 콘솔 로만 출력 합니다. (파일 저장 X)  &ndash;&gt;-->
-    <!--    <logger name="p6spy" level="debug" additivity="false">-->
-    <!--        <appender-ref ref="SQL-LOG-FILE"/>-->
-    <!--    </logger>-->
-
-    <!-- (3) root info 레벨은 파일과 콘솔에 모두 출력 합니다. -->
-    <root level="info">
+    <!-- (1) 프로젝트 전체 로그 설정  -->
+    <logger name="techpick.api" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
+    <logger name="techpick.core" level="info" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="APP-LOG-FILE"/>
+    </logger>
+
+    <logger name="p6spy" level="info" additivity="false">
         <appender-ref ref="SQL-LOG-FILE"/>
-    </root>
+    </logger>
 
 
 </configuration>

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiException.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiException.java
@@ -1,5 +1,7 @@
 package techpick.core.exception.base;
 
+import techpick.core.util.CachedHttpServletRequest;
+
 public abstract class ApiException extends RuntimeException {
 
 	private final ApiErrorCode errorCode;
@@ -13,7 +15,7 @@ public abstract class ApiException extends RuntimeException {
 		return errorCode;
 	}
 
-	public final void handleErrorByLevel() {
-		errorCode.getErrorLevel().handleError(this);
+	public final void handleErrorByLevel(CachedHttpServletRequest request) {
+		errorCode.getErrorLevel().handleError(this, request);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
@@ -5,12 +5,17 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.exception.level.ErrorLevel;
+import techpick.core.util.RequestHolder;
 
 @RestControllerAdvice
 @Slf4j
+@RequiredArgsConstructor
 public class ApiExceptionHandler {
+
+	private final RequestHolder requestHolder;
 
 	/**
 	 * ApiException 에서 잡지 못한 예외는
@@ -19,14 +24,14 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	public ApiErrorResponse handleGlobalException(Exception exception) {
 
-		ErrorLevel.MUST_NEVER_HAPPEN().handleError(exception);
+		ErrorLevel.MUST_NEVER_HAPPEN().handleError(exception, requestHolder.getRequest());
 
 		return ApiErrorResponse.UNKNOWN_SERVER_ERROR();
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ApiErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
-		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception);
+		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception, requestHolder.getRequest());
 		return ApiErrorResponse.VALIDATION_ERROR();
 	}
 
@@ -36,7 +41,7 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(ApiException.class)
 	public ApiErrorResponse handleApiException(ApiException exception) {
 
-		exception.handleErrorByLevel();
+		exception.handleErrorByLevel(requestHolder.getRequest());
 
 		return ApiErrorResponse.of(exception.getApiErrorCode());
 	}
@@ -45,7 +50,7 @@ public class ApiExceptionHandler {
 	// 참고 : https://be-student.tistory.com/52
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ApiErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
-		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception);
+		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception, requestHolder.getRequest());
 		return ApiErrorResponse.INVALID_JSON_ERROR();
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/level/ErrorLevel.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/level/ErrorLevel.java
@@ -2,38 +2,39 @@ package techpick.core.exception.level;
 
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.exception.base.ApiException;
+import techpick.core.util.CachedHttpServletRequest;
 
 @Slf4j
 public abstract class ErrorLevel {
 
 	/**
-	 *  (1) 정상 예외 이며, 따로, 대응 하지 않아도 되는 예외.
-	 *      - 서버가 잘못된 사용자 요청을 잘 처리한 경우
+	 * (1) 정상 예외 이며, 따로, 대응 하지 않아도 되는 예외.
+	 * - 서버가 잘못된 사용자 요청을 잘 처리한 경우
 	 */
 	public static ErrorLevel CAN_HAPPEN() {
 		return new NormalErrorLevel();
 	}
 
 	/**
-	 *  (2) 대응 하지 않아도 되지만, 예의 주시 해야 하는 예외.
-	 *      - 정상 운영은 되지만, 애초에 그 요청이 발생 해선 안되는 경우. Ex. 프론트 엔드 버그
+	 * (2) 대응 하지 않아도 되지만, 예의 주시 해야 하는 예외.
+	 * - 정상 운영은 되지만, 애초에 그 요청이 발생 해선 안되는 경우. Ex. 프론트 엔드 버그
 	 */
 	public static ErrorLevel SHOULD_NOT_HAPPEN() {
 		return new WarningErrorLevel();
 	}
 
 	/**
-	 *  (3) 즉시 대응이 필요한 예외
-	 *      - 운영환경 에서 절대 발생해선 안되며, 발생 시 서버를 즉시 종료해야 하는 경우.
+	 * (3) 즉시 대응이 필요한 예외
+	 * - 운영환경 에서 절대 발생해선 안되며, 발생 시 서버를 즉시 종료해야 하는 경우.
 	 */
 	public static ErrorLevel MUST_NEVER_HAPPEN() {
 		return new FatalErrorLevel();
 	}
 
 	/* Must be implemented per error level */
-	public abstract void handleError(ApiException exception);
+	public abstract void handleError(ApiException exception, CachedHttpServletRequest request);
 
-	public final void handleError(Exception exception) {
-		log.error(exception.getMessage(), exception);
+	public final void handleError(Exception exception, CachedHttpServletRequest request) {
+		log.error("{}\n{}\n{}", exception.getMessage(), exception, request.toString());
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/level/FatalErrorLevel.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/level/FatalErrorLevel.java
@@ -2,12 +2,13 @@ package techpick.core.exception.level;
 
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.exception.base.ApiException;
+import techpick.core.util.CachedHttpServletRequest;
 
 @Slf4j
 public class FatalErrorLevel extends ErrorLevel {
 
 	@Override
-	public void handleError(ApiException exception) {
-		log.error(exception.getMessage(), exception);
+	public void handleError(ApiException exception, CachedHttpServletRequest request) {
+		log.error(exception.getMessage(), exception, request);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/level/NormalErrorLevel.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/level/NormalErrorLevel.java
@@ -9,6 +9,6 @@ public class NormalErrorLevel extends ErrorLevel {
 
 	@Override
 	public void handleError(ApiException exception, CachedHttpServletRequest request) {
-		log.info(exception.getMessage());
+		log.info(exception.getMessage(), exception, request);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/level/NormalErrorLevel.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/level/NormalErrorLevel.java
@@ -2,12 +2,13 @@ package techpick.core.exception.level;
 
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.exception.base.ApiException;
+import techpick.core.util.CachedHttpServletRequest;
 
 @Slf4j
 public class NormalErrorLevel extends ErrorLevel {
 
 	@Override
-	public void handleError(ApiException exception) {
+	public void handleError(ApiException exception, CachedHttpServletRequest request) {
 		log.info(exception.getMessage());
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/exception/level/WarningErrorLevel.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/level/WarningErrorLevel.java
@@ -2,12 +2,13 @@ package techpick.core.exception.level;
 
 import lombok.extern.slf4j.Slf4j;
 import techpick.core.exception.base.ApiException;
+import techpick.core.util.CachedHttpServletRequest;
 
 @Slf4j
 public class WarningErrorLevel extends ErrorLevel {
 
 	@Override
-	public void handleError(ApiException exception) {
-		log.warn(exception.getMessage(), exception);
+	public void handleError(ApiException exception, CachedHttpServletRequest request) {
+		log.warn(exception.getMessage(), exception, request);
 	}
 }

--- a/backend/techpick-core/src/main/java/techpick/core/filter/RequestLoggingFilter.java
+++ b/backend/techpick-core/src/main/java/techpick/core/filter/RequestLoggingFilter.java
@@ -27,6 +27,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			requestHolder.setRequest(cachedRequest);
 			filterChain.doFilter(cachedRequest, response);
 		} finally {
+			// 요청이 마무리되면 무조건 ThreadLocal에 저장한 요청정보를 초기화
 			requestHolder.clearRequest();
 		}
 	}

--- a/backend/techpick-core/src/main/java/techpick/core/filter/RequestLoggingFilter.java
+++ b/backend/techpick-core/src/main/java/techpick/core/filter/RequestLoggingFilter.java
@@ -1,0 +1,33 @@
+package techpick.core.filter;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import techpick.core.util.CachedHttpServletRequest;
+import techpick.core.util.RequestHolder;
+
+@Component
+@RequiredArgsConstructor
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+	private final RequestHolder requestHolder;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			CachedHttpServletRequest cachedRequest = new CachedHttpServletRequest(request);
+			requestHolder.setRequest(cachedRequest);
+			filterChain.doFilter(cachedRequest, response);
+		} finally {
+			requestHolder.clearRequest();
+		}
+	}
+}

--- a/backend/techpick-core/src/main/java/techpick/core/util/CachedHttpServletRequest.java
+++ b/backend/techpick-core/src/main/java/techpick/core/util/CachedHttpServletRequest.java
@@ -1,0 +1,95 @@
+package techpick.core.util;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.Getter;
+
+@Getter
+public class CachedHttpServletRequest extends HttpServletRequestWrapper {
+
+	private final String cachedBody;
+	private final Map<String, Object> infoMap = new HashMap<>();
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@Override
+	public String toString() {
+		try {
+			return mapper.writeValueAsString(infoMap);
+		} catch (JsonProcessingException e) {
+			return e.getMessage();
+		}
+	}
+
+	public CachedHttpServletRequest(HttpServletRequest request) throws IOException {
+		super(request);
+		cachedBody = readBodyFromRequest(request);
+		infoMap.put("requestURI", request.getRequestURI());
+		infoMap.put("method", request.getMethod());
+		infoMap.put("requestBody", cachedBody);
+		infoMap.put("requestTime", LocalDateTime.now().toString());
+		Map<String, String> cookieMap = new HashMap<>();
+		for (Cookie cookie : request.getCookies()) {
+			cookieMap.put(cookie.getName(), cookie.getValue());
+		}
+		if (!cookieMap.isEmpty()) {
+			infoMap.put("cookies", cookieMap);
+		}
+	}
+
+	private String readBodyFromRequest(HttpServletRequest request) throws IOException {
+		try (BufferedReader reader = new BufferedReader(
+			new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8))) {
+			return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+		}
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		return new BufferedReader(new InputStreamReader(
+			new ByteArrayInputStream(cachedBody.getBytes(StandardCharsets.UTF_8))));
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+			cachedBody.getBytes(StandardCharsets.UTF_8));
+		return new ServletInputStream() {
+			@Override
+			public boolean isFinished() {
+				return byteArrayInputStream.available() == 0;
+			}
+
+			@Override
+			public boolean isReady() {
+				return true;
+			}
+
+			@Override
+			public void setReadListener(ReadListener readListener) {
+				// Not required for this implementation
+			}
+
+			@Override
+			public int read() throws IOException {
+				return byteArrayInputStream.read();
+			}
+		};
+	}
+}
+

--- a/backend/techpick-core/src/main/java/techpick/core/util/CachedHttpServletRequest.java
+++ b/backend/techpick-core/src/main/java/techpick/core/util/CachedHttpServletRequest.java
@@ -20,6 +20,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import lombok.Getter;
 
+/**
+ * HttpServletRequest의 경우 reqeust body를 한번 읽으면 소모되기 때문에,
+ * 로깅을 위해 controller 전에 body를 읽는경우 controller에서 body 정보를 가져올 수 없음
+ * 이를위해 body를 미리 읽고 캐싱해둘수 있는 wrapper 클래스 사용
+ * */
 @Getter
 public class CachedHttpServletRequest extends HttpServletRequestWrapper {
 
@@ -39,6 +44,7 @@ public class CachedHttpServletRequest extends HttpServletRequestWrapper {
 	public CachedHttpServletRequest(HttpServletRequest request) throws IOException {
 		super(request);
 		cachedBody = readBodyFromRequest(request);
+		// 추가로 로깅하려는 내용은 여기에 추가해주세요
 		infoMap.put("requestURI", request.getRequestURI());
 		infoMap.put("method", request.getMethod());
 		infoMap.put("requestBody", cachedBody);

--- a/backend/techpick-core/src/main/java/techpick/core/util/RequestHolder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/util/RequestHolder.java
@@ -1,0 +1,22 @@
+package techpick.core.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RequestHolder {
+
+	private final ThreadLocal<CachedHttpServletRequest> requestHolder = new ThreadLocal<>();
+
+	public void setRequest(CachedHttpServletRequest request) {
+		requestHolder.set(request);
+	}
+
+	public CachedHttpServletRequest getRequest() {
+		return requestHolder.get();
+	}
+
+	public void clearRequest() {
+		requestHolder.remove();
+	}
+}
+

--- a/backend/techpick-core/src/main/java/techpick/core/util/RequestHolder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/util/RequestHolder.java
@@ -2,6 +2,10 @@ package techpick.core.util;
 
 import org.springframework.stereotype.Component;
 
+/**
+ * Request에 대한 정보를 저장해두기 위한 클래스
+ * 각 Request는 스레드와 1:1 매칭되므로, 캐싱한 요청정보를 ThreadLocal에 저장
+ * */
 @Component
 public class RequestHolder {
 


### PR DESCRIPTION
- Close #480

## What is this PR? 🔍

- 기능 : 에러 요청에 대한 로깅 구현
- issue : #480

## Changes 📝

기존에는 예외에 대해 에러코드와 메세지만 로깅했지만, 이것으로는 디버깅  및 행동분석에 부족하다고 판단되어
예외 발생 시 해당 요청을 로깅하는 기능을 구현

필터를 구현해 모든 요청을 `CachedHttpServletRequest`에 캐싱하고
`CachedHttpServletRequest`객체를 `ThreadLocal`에 저장
이후 예외가 발생하면, 캐싱한 `CachedHttpServletRequest`를 꺼내와서 요청을 로깅

로깅예시
```
{
  "requestTime": "2024-11-18T23:19:08.174014",
  "method": "DELETE",
  "requestBody": "{\n이건 잘못된 Json 요청입니다.",
  "requestURI": "/api/folders",
  "cookies": {
    "access_token": "(엑세스토큰 값)",
    "JSESSIONID": "(세션ID)",
    "techPickLogin": "true"
  }
}
```
## Precaution

이것 외에도 실제 예외가 발생했을때의 파라미터를 로깅하는 기능 추가 필요
