### PR TITLE
[FEAT] 픽 제목 최대 길이 검증 및 Validation 검증 리팩토링

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
@@ -9,27 +9,27 @@ import jakarta.validation.constraints.NotNull;
 public class FolderApiRequest {
 
 	public record Create(
-		@Schema(example = "backend") @NotBlank String name,
-		@Schema(example = "3") @NotNull Long parentFolderId
+		@Schema(example = "backend") @NotBlank(message = "{folder.name.notBlank}") String name,
+		@Schema(example = "3") @NotNull(message = "{parentFolderId.notNull}") Long parentFolderId
 	) {
 	}
 
 	public record Update(
-		@Schema(example = "3") @NotNull Long id,
-		@Schema(example = "SpringBoot") @NotBlank String name
+		@Schema(example = "3") @NotNull(message = "{id.notNull}") Long id,
+		@Schema(example = "SpringBoot") @NotBlank(message = "{folder.name.notBlank}") String name
 	) {
 	}
 
 	public record Move(
-		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList,
-		@Schema(example = "7") @NotNull Long parentFolderId,
-		@Schema(example = "3") @NotNull Long destinationFolderId,
+		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull(message = "{idList.notNull}") List<Long> idList,
+		@Schema(example = "7") @NotNull(message = "{parentFolderId.notNull}") Long parentFolderId,
+		@Schema(example = "3") @NotNull(message = "{destinationFolderId.notNull}") Long destinationFolderId,
 		@Schema(example = "2") int orderIdx
 	) {
 	}
 
 	public record Delete(
-		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull List<Long> idList
+		@Schema(example = "[12, 11, 4, 5, 1, 6]") @NotNull(message = "{idList.notNull}") List<Long> idList
 	) {
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -21,15 +21,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import techpick.api.application.pick.dto.PickApiMapper;
 import techpick.api.application.pick.dto.PickApiRequest;
 import techpick.api.application.pick.dto.PickApiResponse;
 import techpick.api.application.pick.dto.PickSliceResponse;
 import techpick.api.domain.pick.dto.PickResult;
+import techpick.api.domain.pick.exception.ApiPickException;
 import techpick.api.domain.pick.service.PickSearchService;
 import techpick.api.domain.pick.service.PickService;
 import techpick.security.annotation.LoginUserId;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/picks")
@@ -108,6 +111,10 @@ public class PickApiController {
 	})
 	public ResponseEntity<PickApiResponse.Pick> savePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Create request) {
+		if (request.title().length() > 200) {
+			throw ApiPickException.PICK_TITLE_TOO_LONG();
+		}
+
 		return ResponseEntity.ok(
 			pickApiMapper.toApiResponse(pickService.saveNewPick(pickApiMapper.toCreateCommand(userId, request))));
 	}
@@ -119,6 +126,10 @@ public class PickApiController {
 	})
 	public ResponseEntity<PickApiResponse.Pick> updatePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Update request) {
+		if (request.title().length() > 200) {
+			throw ApiPickException.PICK_TITLE_TOO_LONG();
+		}
+
 		return ResponseEntity.ok(
 			pickApiMapper.toApiResponse(pickService.updatePick(pickApiMapper.toUpdateCommand(userId, request))));
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
@@ -17,12 +17,12 @@ public class PickApiRequest {
 	}
 
 	public record Read(
-		@Schema(example = "1") @NotNull Long id
+		@Schema(example = "1") @NotNull(message = "{id.notNull}") Long id
 	) {
 	}
 
 	public record Update(
-		@Schema(example = "1") @NotNull Long id,
+		@Schema(example = "1") @NotNull(message = "{id.notNull}") Long id,
 		@Schema(example = "Record란 뭘까?") String title,
 		@Schema(example = "3") Long parentFolderId,
 		@Schema(example = "[4, 5, 2, 1]") List<Long> tagIdOrderedList
@@ -30,14 +30,14 @@ public class PickApiRequest {
 	}
 
 	public record Move(
-		@Schema(example = "[1, 2]") @NotNull List<Long> idList,
-		@Schema(example = "3") @NotNull Long destinationFolderId,
+		@Schema(example = "[1, 2]") @NotNull(message = "{idList.notNull}") List<Long> idList,
+		@Schema(example = "3") @NotNull(message = "{destinationFolderId.notNull}") Long destinationFolderId,
 		@Schema(example = "0") int orderIdx
 	) {
 	}
 
 	public record Delete(
-		@Schema(example = "[1]") @NotNull List<Long> idList
+		@Schema(example = "[1]") @NotNull(message = "{idList.notNull}") List<Long> idList
 	) {
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/application/tag/dto/TagApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/tag/dto/TagApiRequest.java
@@ -8,28 +8,28 @@ import jakarta.validation.constraints.NotNull;
 public class TagApiRequest {
 
 	public record Create(
-		@Schema(example = "SpringBoot") @NotBlank String name,
-		@Schema(example = "12") @NotNull Integer colorNumber) {
+		@Schema(example = "SpringBoot") @NotBlank(message = "{tag.name.notBlank}") String name,
+		@Schema(example = "12") @NotNull(message = "{tag.colorNumber.notNull}") Integer colorNumber) {
 	}
 
 	public record Read(
-		@Schema(example = "2") @NotNull Long id) {
+		@Schema(example = "2") @NotNull(message = "{id.notNull}") Long id) {
 	}
 
 	public record Update(
-		@Schema(example = "2") @NotNull Long id,
-		@Schema(example = "new tag name") @NotEmpty String name,
-		@Schema(example = "7") @NotNull Integer colorNumber) {
+		@Schema(example = "2") @NotNull(message = "{id.notNull}") Long id,
+		@Schema(example = "new tag name") @NotEmpty(message = "{tag.name.notBlank}") String name,
+		@Schema(example = "7") @NotNull(message = "{tag.colorNumber.notNull}") Integer colorNumber) {
 	}
 
 	public record Move(
-		@Schema(example = "3") @NotNull Long id,
-		@Schema(example = "1") @NotNull int orderIdx
+		@Schema(example = "3") @NotNull(message = "{id.notNull}") Long id,
+		@Schema(example = "1") int orderIdx
 	) {
 	}
 
 	public record Delete(
-		@Schema(example = "4") @NotNull Long id
+		@Schema(example = "4") @NotNull(message = "{id.notNull}") Long id
 	) {
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/config/ValidationConfig.java
+++ b/backend/techpick-api/src/main/java/techpick/api/config/ValidationConfig.java
@@ -1,0 +1,28 @@
+package techpick.api.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class ValidationConfig {
+
+	@Bean
+	public MessageSource messageSource() {
+		ReloadableResourceBundleMessageSource messageSource
+			= new ReloadableResourceBundleMessageSource();
+
+		messageSource.setBasename("classpath:messages");
+		messageSource.setDefaultEncoding("UTF-8");
+		return messageSource;
+	}
+
+	@Bean
+	public LocalValidatorFactoryBean getValidator() {
+		LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+		bean.setValidationMessageSource(messageSource());
+		return bean;
+	}
+}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/exception/ApiPickErrorCode.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/exception/ApiPickErrorCode.java
@@ -19,7 +19,9 @@ public enum ApiPickErrorCode implements ApiErrorCode {
 	PICK_UNAUTHORIZED_ROOT_ACCESS
 		("PK-003", HttpStatus.UNAUTHORIZED, "잘못된 Pick 접근, 폴더가 아닌 Root에 접근", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	PICK_DELETE_NOT_ALLOWED
-		("PK-004", HttpStatus.NOT_ACCEPTABLE, "휴지통이 아닌 폴더에서 픽 삭제는 허용되지 않음.", ErrorLevel.SHOULD_NOT_HAPPEN()),
+		("PK-004", HttpStatus.NOT_ACCEPTABLE, "휴지통이 아닌 폴더에서 픽 삭제는 허용되지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
+	PICK_TITLE_TOO_LONG
+		("PK-005", HttpStatus.BAD_REQUEST, "픽 제목이 허용된 최대 길이를 초과했습니다", ErrorLevel.CAN_HAPPEN()),
 	;
 
 	private final String code;

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/exception/ApiPickException.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/exception/ApiPickException.java
@@ -28,4 +28,8 @@ public class ApiPickException extends ApiException {
 	public static ApiPickException PICK_DELETE_NOT_ALLOWED() {
 		return new ApiPickException(ApiPickErrorCode.PICK_DELETE_NOT_ALLOWED);
 	}
+
+	public static ApiPickException PICK_TITLE_TOO_LONG() {
+		return new ApiPickException(ApiPickErrorCode.PICK_TITLE_TOO_LONG);
+	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
@@ -73,12 +73,9 @@ public class TagDataHandler {
 	}
 
 	@Transactional
-	public List<Long> moveTag(Long userId, TagCommand.Move command) {
+	public void moveTag(Long userId, TagCommand.Move command) {
 		User user = userRepository.findById(userId).orElseThrow(ApiUserException::USER_NOT_FOUND);
-		var userTagOrder = user.getTagOrderList();
-		userTagOrder.remove(command.id());
-		userTagOrder.add(command.orderIdx(), command.id());
-		return userTagOrder;
+		user.updateTagOrderList(command.id(), command.orderIdx());
 	}
 
 	@Transactional

--- a/backend/techpick-api/src/main/resources/messages.properties
+++ b/backend/techpick-api/src/main/resources/messages.properties
@@ -1,0 +1,11 @@
+# common
+id.notNull=id는 null일 수 없습니다
+idList.notNull=idList는 null일 수 없습니다
+parentFolderId.notNull=부모 폴더 id는 null일 수 없습니다.
+destinationFolderId.notNull=이동할 폴더 id는 null일 수 없습니다.
+# folder
+folder.name.notBlank=Folder 이름은 비어있을 수 없습니다.
+# tag
+tag.name.notBlank=Tag 이름은 비어있을 수 없습니다.
+tag.colorNumber.notNull=Tag 색상은 null일 수 없습니다.
+tag.orderIdx.notNull=Tag 순서는 null일 수 없습니다.

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiErrorResponse.java
@@ -20,8 +20,8 @@ public class ApiErrorResponse extends ResponseEntity<ApiErrorBody> {
 		return new ApiErrorResponse(apiErrorCode);
 	}
 
-	public static ApiErrorResponse VALIDATION_ERROR() {
-		return new ApiErrorResponse("VALIDATION ERROR", "DTO @Valid 검증 에러, 잘못된 값 입력", HttpStatus.BAD_REQUEST);
+	public static ApiErrorResponse VALIDATION_ERROR(String message) {
+		return new ApiErrorResponse("VALIDATION ERROR", message, HttpStatus.BAD_REQUEST);
 	}
 
 	public static ApiErrorResponse UNKNOWN_SERVER_ERROR() {

--- a/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
+++ b/backend/techpick-core/src/main/java/techpick/core/exception/base/ApiExceptionHandler.java
@@ -27,7 +27,7 @@ public class ApiExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ApiErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
 		ErrorLevel.SHOULD_NOT_HAPPEN().handleError(exception);
-		return ApiErrorResponse.VALIDATION_ERROR();
+		return ApiErrorResponse.VALIDATION_ERROR(exception.getBindingResult().getFieldError().getDefaultMessage());
 	}
 
 	/**

--- a/backend/techpick-core/src/main/java/techpick/core/model/user/User.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/user/User.java
@@ -75,8 +75,10 @@ public class User extends BaseEntity /* implements UserDetails --> 시큐리티 
 	@Column(name = "tag_order", columnDefinition = "longblob", nullable = false)
 	private List<Long> tagOrderList = new ArrayList<>();
 
-	public void updateTagOrderList(List<Long> tagOrderList) {
-		this.tagOrderList = tagOrderList;
+	public void updateTagOrderList(Long id, int destination) {
+		tagOrderList.remove(id);
+		int calculatedDestination = Math.min(destination, tagOrderList.size());
+		tagOrderList.add(calculatedDestination, id);
 	}
 
 	@Override


### PR DESCRIPTION
- Close #487 

## What is this PR? 🔍

- 기능 : 픽 제목 최대 길이 검증 및 Validation 검증 리팩토링, 태그 이동 버그 수정
- issue : #487 

## Changes 📝
- 픽 생성, 수정 시 제목 최대 길이(200자) 검증 로직 추가
- 현재 Validation 예외는 공통 예외 메시지를 던지고 있음. 각 필드 별 다른 예외 메시지를 던지도록 수정
- Tag 이동 시 리스트 길이보다 큰 인덱스로 이동하려고 할 때 IndexOutOfBoundsException 문제 해결

