### PR TITLE
[DESIGN] 익스텐션 디자인 변경

### DIFF
--- a/frontend/techpick-extension/src/components/DeselectTagButton.css.ts
+++ b/frontend/techpick-extension/src/components/DeselectTagButton.css.ts
@@ -2,6 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
 
 export const DeselectTagButtonStyle = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
   width: '20px',
   height: '20px',
   backgroundColor: 'transparent',


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 :
- issue : #

## Changes 📝
- 익스텐션의 x가 가운데 오게 했습니다.
## ScreenShot 📷
![스크린샷 2024-11-19 오후 7 18 48](https://github.com/user-attachments/assets/adfad583-7364-481f-865e-d68bc3cb00f7)


<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
