### PR TITLE
[FEAT] 폴더 export 기능 구현

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderMigrationController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderMigrationController.java
@@ -18,7 +18,7 @@ import techpick.security.annotation.LoginUserId;
 public class FolderMigrationController {
 	private final FolderMigrationService folderMigrationService;
 
-	@GetMapping("/folders/{folderId}/export")
+	@GetMapping("/api/folders/{folderId}/export")
 	public ResponseEntity<ByteArrayResource> exportFolder(@LoginUserId Long userId, @PathVariable Long folderId) {
 		String exportResult = folderMigrationService.exportFolder(new FolderCommand.Export(userId, folderId));
 
@@ -34,7 +34,7 @@ public class FolderMigrationController {
 			.body(resource);
 	}
 
-	@GetMapping("/folders/export")
+	@GetMapping("/api/folders/export")
 	public ResponseEntity<ByteArrayResource> exportUserFolder(@LoginUserId Long userId) {
 		String exportResult = folderMigrationService.exportUserFolder(userId);
 

--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderMigrationController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/controller/FolderMigrationController.java
@@ -1,0 +1,52 @@
+package techpick.api.application.folder.controller;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import techpick.api.domain.folder.dto.FolderCommand;
+import techpick.api.domain.folder.service.FolderMigrationService;
+import techpick.security.annotation.LoginUserId;
+
+@RestController
+@RequiredArgsConstructor
+public class FolderMigrationController {
+	private final FolderMigrationService folderMigrationService;
+
+	@GetMapping("/folders/{folderId}/export")
+	public ResponseEntity<ByteArrayResource> exportFolder(@LoginUserId Long userId, @PathVariable Long folderId) {
+		String exportResult = folderMigrationService.exportFolder(new FolderCommand.Export(userId, folderId));
+
+		ByteArrayResource resource = new ByteArrayResource(exportResult.getBytes());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=exported-folder.html");
+		headers.add(HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.headers(headers)
+			.body(resource);
+	}
+
+	@GetMapping("/folders/export")
+	public ResponseEntity<ByteArrayResource> exportUserFolder(@LoginUserId Long userId) {
+		String exportResult = folderMigrationService.exportUserFolder(userId);
+
+		ByteArrayResource resource = new ByteArrayResource(exportResult.getBytes());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=exported-folder.html");
+		headers.add(HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.headers(headers)
+			.body(resource);
+	}
+}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/dto/FolderCommand.java
@@ -44,4 +44,10 @@ public class FolderCommand {
 		List<Long> idList
 	) {
 	}
+
+	public record Export(
+		Long userId,
+		Long folderId
+	) {
+	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderMigrationService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderMigrationService.java
@@ -1,0 +1,74 @@
+package techpick.api.domain.folder.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import techpick.api.domain.folder.dto.FolderCommand;
+import techpick.api.domain.folder.exception.ApiFolderException;
+import techpick.api.infrastructure.folder.FolderDataHandler;
+import techpick.api.infrastructure.pick.PickDataHandler;
+import techpick.core.model.folder.Folder;
+import techpick.core.model.pick.Pick;
+
+/**
+ * 폴더 Import와 Export를 담당하는 서비스
+ * 크롬브라우저에 import 가능한 형식으로 저장한 폴더들과 픽들을 export
+ * 크롬브라우저에서 export한 html을 Techpick에 import
+ * */
+@Service
+@RequiredArgsConstructor
+public class FolderMigrationService {
+
+	private final FolderDataHandler folderDataHandler;
+	private final PickDataHandler pickDataHandler;
+
+	@Transactional(readOnly = true)
+	public String exportFolder(FolderCommand.Export command) {
+		StringBuilder sb = new StringBuilder();
+		Folder folder = folderDataHandler.getFolder(command.folderId());
+		validateFolderAccess(command.userId(), folder);
+
+		return DFS(new StringBuilder(), folder).toString();
+	}
+
+	@Transactional(readOnly = true)
+	public String exportUserFolder(Long userId) {
+		StringBuilder sb = new StringBuilder();
+		DFS(sb, folderDataHandler.getUnclassifiedFolder(userId));
+		DFS(sb, folderDataHandler.getRootFolder(userId));
+		DFS(sb, folderDataHandler.getRecycleBin(userId));
+		return sb.toString();
+	}
+
+	private StringBuilder DFS(StringBuilder sb, Folder folder) {
+		sb.append("<DT>").append("<H3>").append(folder.getName()).append("</H3>\n");
+		sb.append("<DL>\n");
+		List<Folder> childFolderList = folderDataHandler.getFolderListPreservingOrder(
+			folder.getChildFolderIdOrderedList());
+		// 자식폴더를 순회하며 추가
+		for (Folder childFolder : childFolderList) {
+			DFS(sb, childFolder);
+		}
+		// 자식픽들을 순회하며 추가
+		List<Pick> childPickList = pickDataHandler.getPickListPreservingOrder(folder.getChildPickIdOrderedList());
+		for (Pick pick : childPickList) {
+			sb.append("<DT>")
+				.append("<A HREF=\"")
+				.append(pick.getLink().getUrl())
+				.append("\">")
+				.append(pick.getTitle())
+				.append("</A>\n");
+		}
+		sb.append("</DL>\n");
+		return sb;
+	}
+
+	private void validateFolderAccess(Long userId, Folder folder) {
+		if (!folder.getUser().getId().equals(userId)) {
+			throw ApiFolderException.FOLDER_ACCESS_DENIED();
+		}
+	}
+}


### PR DESCRIPTION
- Close #495

## What is this PR? 🔍

- 기능 : 폴더 export 기능 구현
- issue : #495

## Changes 📝

본인의 폴더와 픽들을 크롬에 import 가능한 html형식으로 다운로드 받습니다.
- `/api/folders/export` : 본인의 모든 폴더(미분류, 휴지통 포함)를 추출합니다.
- `/api/folders/{folderId}/export` : 특정 폴더 및 하위 폴더/픽들을 추출합니다.