### PR TITLE
[BUG] 픽 태그 삭제 버그, 픽 수정 버그 수정

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderErrorCode.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderErrorCode.java
@@ -23,14 +23,14 @@ public enum ApiFolderErrorCode implements ApiErrorCode {
 	INVALID_FOLDER_TYPE
 		("FO-005", HttpStatus.NOT_IMPLEMENTED, "미구현 폴더 타입에 대한 서비스 요청", ErrorLevel.MUST_NEVER_HAPPEN()),
 	BASIC_FOLDER_ALREADY_EXISTS
-		("FO-006", HttpStatus.NOT_ACCEPTABLE, "기본 폴더는 1개만 존재할 수 있음.", ErrorLevel.MUST_NEVER_HAPPEN()),
-	INVALID_MOVE_TARGET
-		("FO-007", HttpStatus.NOT_ACCEPTABLE, "이동하려는 폴더들의 범위가 올바르지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
+		("FO-006", HttpStatus.NOT_ACCEPTABLE, "기본 폴더는 1개만 존재할 수 있음", ErrorLevel.MUST_NEVER_HAPPEN()),
+	INVALID_TARGET
+		("FO-007", HttpStatus.NOT_ACCEPTABLE, "휴지통 또는 미분류 폴더에 폴더를 (생성/이동)할 수 없음", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	INVALID_PARENT_FOLDER
 		("FO-008", HttpStatus.NOT_ACCEPTABLE, "부모 폴더가 올바르지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	// TODO: folder depth 추가 시 예외 삭제 예정
 	ROOT_FOLDER_SEARCH_NOT_ALLOWED
-		("FO-009", HttpStatus.NOT_ACCEPTABLE, "루트 폴더에 대한 검색은 허용되지 않음.", ErrorLevel.SHOULD_NOT_HAPPEN()),
+		("FO-009", HttpStatus.NOT_ACCEPTABLE, "루트 폴더에 대한 검색은 허용되지 않음", ErrorLevel.SHOULD_NOT_HAPPEN()),
 	;
 
 	private final String code;

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderException.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/exception/ApiFolderException.java
@@ -40,8 +40,8 @@ public class ApiFolderException extends ApiException {
 		return new ApiFolderException(ApiFolderErrorCode.BASIC_FOLDER_ALREADY_EXISTS);
 	}
 
-	public static ApiFolderException INVALID_MOVE_TARGET() {
-		return new ApiFolderException(ApiFolderErrorCode.INVALID_MOVE_TARGET);
+	public static ApiFolderException INVALID_TARGET() {
+		return new ApiFolderException(ApiFolderErrorCode.INVALID_TARGET);
 	}
 
 	public static ApiFolderException INVALID_PARENT_FOLDER() {

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -53,7 +53,6 @@ public class FolderService {
 	}
 
 	// TODO: 현재는 1depth만 반환하고 있지만, 추후 ~3depth까지 반환할 예정
-	// Root 폴더를 받아야하는 이유가 있나..? 내일 승태님께 물어보기
 	@Transactional(readOnly = true)
 	public List<FolderResult> getAllRootFolderList(Long userId) {
 		Folder rootFolder = folderDataHandler.getRootFolder(userId);
@@ -80,10 +79,14 @@ public class FolderService {
 			.toList();
 	}
 
+	/**
+	 * 생성하려는 폴더가 미분류폴더, 휴지통이 아닌지 검증합니다.
+	 * */
 	@Transactional
 	public FolderResult saveFolder(FolderCommand.Create command) {
 		Folder parentFolder = folderDataHandler.getFolder(command.parentFolderId());
 		validateFolderAccess(command.userId(), parentFolder);
+		validateDestinationFolder(parentFolder);
 
 		return folderMapper.toResult(folderDataHandler.saveFolder(command));
 	}
@@ -181,14 +184,14 @@ public class FolderService {
 	}
 
 	/**
-	 * 폴더 이동시 미분류폴더, 휴지통으로는 이동할 수 없습니다.
+	 * 폴더 생성, 이동시 미분류폴더, 휴지통으로는 이동할 수 없습니다.
 	 * */
 	private void validateDestinationFolder(Folder destinationFolder) {
 		if (Objects.equals(destinationFolder.getFolderType(), FolderType.UNCLASSIFIED)) {
-			throw ApiFolderException.INVALID_MOVE_TARGET();
+			throw ApiFolderException.INVALID_TARGET();
 		}
 		if (Objects.equals(destinationFolder.getFolderType(), FolderType.RECYCLE_BIN)) {
-			throw ApiFolderException.INVALID_MOVE_TARGET();
+			throw ApiFolderException.INVALID_TARGET();
 		}
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -99,7 +99,9 @@ public class PickDataHandler {
 			});
 
 		Pick savedPick = pickRepository.save(pickMapper.toEntity(command, user, folder, link));
-		savedPick.getParentFolder().addChildPickIdOrdered(savedPick.getId());
+		Folder parentFolder = savedPick.getParentFolder();
+		attachPickToParentFolder(savedPick, parentFolder);
+
 		List<PickTag> pickTagList = tagRepository.findAllById(command.tagIdOrderedList())
 			.stream()
 			.map(tag -> PickTag.of(savedPick, tag))
@@ -109,13 +111,23 @@ public class PickDataHandler {
 		return savedPick;
 	}
 
+	/**
+	 * 부모 폴더 픽 리스트에서 pick 제거 후
+	 * 이동하는 폴더 픽 리스트에 pick 추가
+	 */
 	@Transactional
 	public Pick updatePick(PickCommand.Update command) {
 		Pick pick = getPick(command.id());
 		pick.updateTitle(command.title());
+
 		if (command.parentFolderId() != null) {
-			pick.updateParentFolder(
-				folderRepository.findById(command.parentFolderId()).orElseThrow(ApiFolderException::FOLDER_NOT_FOUND));
+			Folder parentFolder = pick.getParentFolder();
+			Folder destinationFolder = folderRepository.findById(command.parentFolderId())
+				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
+
+			detachPickToParentFolder(pick, parentFolder);
+			attachPickToParentFolder(pick, destinationFolder);
+			updatePickParentFolder(pick, destinationFolder);
 		}
 		if (command.tagIdOrderedList() != null) {
 			updateNewTagIdList(pick, command.tagIdOrderedList());
@@ -128,7 +140,7 @@ public class PickDataHandler {
 		List<Long> pickIdList = command.idList();
 		Folder folder = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		folder.updateChildPickIdOrderedList(pickIdList, command.orderIdx());
+		movePickListToDestinationFolder(pickIdList, folder, command.orderIdx());
 	}
 
 	@Transactional
@@ -136,39 +148,43 @@ public class PickDataHandler {
 		List<Long> pickIdList = command.idList();
 		Folder destinationFolder = folderRepository.findById(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
-		destinationFolder.updateChildPickIdOrderedList(pickIdList, command.orderIdx());
 
-		for (Long pickId : pickIdList) {
-			Pick pick = getPick(pickId);
-			pick.getParentFolder().removeChildPickOrder(pickId);
-			pick.updateParentFolder(destinationFolder);
-		}
+		List<Pick> pickList = pickRepository.findAllById(pickIdList);
+		pickList.forEach(pick -> {
+			detachPickToParentFolder(pick, pick.getParentFolder());
+			updatePickParentFolder(pick, destinationFolder);
+		});
+
+		movePickListToDestinationFolder(pickIdList, destinationFolder, command.orderIdx());
 	}
 
 	@Transactional
 	public void movePickListToRecycleBin(Long userId, List<Long> pickIdList) {
-		// 휴지통에 픽 추가
 		Folder recycleBin = folderRepository.findRecycleBinByUserId(userId);
-		recycleBin.getChildPickIdOrderedList().addAll(0, pickIdList);
 
 		// 픽들의 부모를 휴지통으로 변경
 		List<Pick> pickList = pickRepository.findAllById(pickIdList);
-		pickList.forEach(pick -> pick.updateParentFolder(recycleBin));
+		pickList.forEach(pick -> {
+			detachPickToParentFolder(pick, pick.getParentFolder());
+			attachPickToParentFolder(pick, recycleBin);
+			updatePickParentFolder(pick, recycleBin);
+		});
 	}
 
 	@Transactional
 	public void deletePickList(PickCommand.Delete command) {
 		List<Long> pickIdList = command.idList();
-		for (Long pickId : pickIdList) {
-			Pick pick = getPick(pickId);
-			pick.getParentFolder().removeChildPickOrder(pickId);
+		List<Pick> pickList = pickRepository.findAllById(pickIdList);
+
+		pickList.forEach(pick -> {
+			detachPickToParentFolder(pick, pick.getParentFolder());
 			pickTagRepository.deleteByPick(pick);
 			pickRepository.delete(pick);
-		}
+		});
 	}
 
 	@Transactional
-	public void attachTagToPick(Pick pick, Long tagId) {
+	public void attachTagToPickTag(Pick pick, Long tagId) {
 		Tag tag = tagRepository.findById(tagId)
 			.orElseThrow(ApiTagException::TAG_NOT_FOUND);
 		PickTag pickTag = PickTag.of(pick, tag);
@@ -176,20 +192,40 @@ public class PickDataHandler {
 	}
 
 	@Transactional
-	public void detachTagFromPick(Pick pick, Long tagId) {
+	public void detachTagToPickTag(Pick pick, Long tagId) {
 		pickTagRepository.deleteByPickAndTagId(pick, tagId);
+	}
+
+	// 부모 폴더의 픽 리스트에 추가
+	private void attachPickToParentFolder(Pick pick, Folder folder) {
+		folder.addChildPickIdOrdered(pick.getId());
+	}
+
+	// 부모 폴더의 픽 리스트에서 제거
+	private void detachPickToParentFolder(Pick pick, Folder folder) {
+		folder.removeChildPickIdOrdered(pick.getId());
+	}
+
+	// 픽의 부모 폴더 변경
+	private void updatePickParentFolder(Pick pick, Folder folder) {
+		pick.updateParentFolder(folder);
+	}
+
+	// 픽 리스트 순서를 유지한 채 목적지 폴더로 이동
+	private void movePickListToDestinationFolder(List<Long> pickIdList, Folder folder, int orderIdx) {
+		folder.updateChildPickIdOrderedList(pickIdList, orderIdx);
 	}
 
 	private void updateNewTagIdList(Pick pick, List<Long> newTagOrderList) {
 		// 1. 기존 태그와 새로운 태그를 비교하여 없어진 태그를 PickTag 테이블에서 제거
 		pick.getTagIdOrderedList().stream()
 			.filter(tagId -> !newTagOrderList.contains(tagId))
-			.forEach(tagId -> detachTagFromPick(pick, tagId));
+			.forEach(tagId -> detachTagToPickTag(pick, tagId));
 
 		// 2. 새로운 태그 중 기존에 없는 태그를 PickTag 테이블에 추가
 		newTagOrderList.stream()
 			.filter(tagId -> !pick.getTagIdOrderedList().contains(tagId))
-			.forEach(tagId -> attachTagToPick(pick, tagId));
+			.forEach(tagId -> attachTagToPickTag(pick, tagId));
 
 		pick.updateTagOrderList(newTagOrderList);
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -165,7 +165,6 @@ public class PickDataHandler {
 		// 픽들의 부모를 휴지통으로 변경
 		List<Pick> pickList = pickRepository.findAllById(pickIdList);
 		pickList.forEach(pick -> {
-			detachPickToParentFolder(pick, pick.getParentFolder());
 			attachPickToParentFolder(pick, recycleBin);
 			updatePickParentFolder(pick, recycleBin);
 		});

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -125,7 +125,7 @@ public class PickDataHandler {
 			Folder destinationFolder = folderRepository.findById(command.parentFolderId())
 				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
-			detachPickToParentFolder(pick, parentFolder);
+			detachPickFromParentFolder(pick, parentFolder);
 			attachPickToParentFolder(pick, destinationFolder);
 			updatePickParentFolder(pick, destinationFolder);
 		}
@@ -151,7 +151,7 @@ public class PickDataHandler {
 
 		List<Pick> pickList = pickRepository.findAllById(pickIdList);
 		pickList.forEach(pick -> {
-			detachPickToParentFolder(pick, pick.getParentFolder());
+			detachPickFromParentFolder(pick, pick.getParentFolder());
 			updatePickParentFolder(pick, destinationFolder);
 		});
 
@@ -176,7 +176,7 @@ public class PickDataHandler {
 		List<Pick> pickList = pickRepository.findAllById(pickIdList);
 
 		pickList.forEach(pick -> {
-			detachPickToParentFolder(pick, pick.getParentFolder());
+			detachPickFromParentFolder(pick, pick.getParentFolder());
 			pickTagRepository.deleteByPick(pick);
 			pickRepository.delete(pick);
 		});
@@ -191,7 +191,7 @@ public class PickDataHandler {
 	}
 
 	@Transactional
-	public void detachTagToPickTag(Pick pick, Long tagId) {
+	public void detachTagFromPickTag(Pick pick, Long tagId) {
 		pickTagRepository.deleteByPickAndTagId(pick, tagId);
 	}
 
@@ -201,7 +201,7 @@ public class PickDataHandler {
 	}
 
 	// 부모 폴더의 픽 리스트에서 제거
-	private void detachPickToParentFolder(Pick pick, Folder folder) {
+	private void detachPickFromParentFolder(Pick pick, Folder folder) {
 		folder.removeChildPickIdOrdered(pick.getId());
 	}
 
@@ -219,7 +219,7 @@ public class PickDataHandler {
 		// 1. 기존 태그와 새로운 태그를 비교하여 없어진 태그를 PickTag 테이블에서 제거
 		pick.getTagIdOrderedList().stream()
 			.filter(tagId -> !newTagOrderList.contains(tagId))
-			.forEach(tagId -> detachTagToPickTag(pick, tagId));
+			.forEach(tagId -> detachTagFromPickTag(pick, tagId));
 
 		// 2. 새로운 태그 중 기존에 없는 태그를 PickTag 테이블에 추가
 		newTagOrderList.stream()

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/tag/TagDataHandler.java
@@ -92,7 +92,7 @@ public class TagDataHandler {
 			.forEach(pick -> {
 				pick.getTagIdOrderedList().remove(tagId);
 			});
-		pickTagRepository.deleteById(tagId);
+		pickTagRepository.deleteByTagId(tagId);
 		tagRepository.deleteById(tagId);
 	}
 

--- a/backend/techpick-api/src/main/resources/application.yaml
+++ b/backend/techpick-api/src/main/resources/application.yaml
@@ -142,4 +142,9 @@ security:
   default-redirect-url: https://app.techpick.org
   base-url: https://api.techpick.org
 
+# 운영 환경에서 스웨거 접근 못하도록 막는 설정
+springdoc:
+  swagger-ui:
+    enabled: true  # false로 변경하면, swagger 접근 불가
+
 ---

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
@@ -123,16 +123,6 @@ public class Folder extends BaseEntity {
 		this.parentFolder = parentFolder;
 	}
 
-	public void updateChildFolderOrder(Long pickId, int destination) {
-		childFolderIdOrderedList.remove(pickId);
-		childFolderIdOrderedList.add(destination, pickId);
-	}
-
-	public void updateChildPickOrder(Long pickId, int destination) {
-		childPickIdOrderedList.remove(pickId);
-		childPickIdOrderedList.add(destination, pickId);
-	}
-
 	public void updateChildPickIdOrderedList(List<Long> pickIdList, int destination) {
 		childPickIdOrderedList.removeAll(pickIdList);
 		int calculatedDestination = Math.min(destination, childPickIdOrderedList.size());
@@ -158,12 +148,8 @@ public class Folder extends BaseEntity {
 		childFolderIdOrderedList.addAll(calculatedDestination, folderIdList);
 	}
 
-	public void removeChildFolderOrder(Long folderId) {
-		this.childFolderIdOrderedList.remove(folderId);
-	}
-
-	public void removeChildPickOrder(Long pickId) {
-		this.childPickIdOrderedList.remove(pickId);
+	public void removeChildPickIdOrdered(Long pickId) {
+		childPickIdOrderedList.remove(pickId);
 	}
 
 	@Builder

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/Pick.java
@@ -29,7 +29,7 @@ import techpick.core.util.OrderConverter;
 	uniqueConstraints = {
 		@UniqueConstraint(
 			name = "UC_PICK_NAME_PER_USER",
-			columnNames = {"user_id", "link_id", "title"}
+			columnNames = {"user_id", "link_id"}
 		)
 	}
 )


### PR DESCRIPTION
- Close #493

## What is this PR? 🔍

- 기능 : 픽 리팩토링
- issue : #493

## Changes 📝
### 1. 픽에 포함된 태그 삭제시 500에러 버그 해결
- 원인 : pickTag 테이블 row 삭제할 때 `tagId를 조건으로 삭제`하는 것이 아닌 `pk를 조건으로 삭제`하여 버그 발생
- 해결 : `tagId로 삭제`하도록 변경

### 2. 픽 수정 시 부모 폴더의 픽 리스트가 수정되지 않는 버그 해결
- 원인 : 픽 수정할 때 부모, 이동할 `폴더의 픽 리스트를 수정하지 않음`.
- 해결 : 픽 수정할 때 부모, 이동할 `폴더의 픽 리스트 제거, 추가하는 로직` 추가

### 3. Pick Unique index 조건 중 title 제거

### 4. PickDataHandler 리팩토링
- 가독성 향상을 위해 리팩토링 진행
- 공통으로 사용되는 로직들 메서드로 분리

### 5. 미분류, 휴지통 폴더에 폴더 생성하지 못하도록 검증 추가
- 에러 메세지, 에러 코드명 변경
- `"이동하려는 폴더들의 범위가 올바르지 않음"` -> `"휴지통 또는 미분류 폴더에 폴더를 (생성/이동)할 수 없음"`

### 6. 운영 환경에서 스웨거 접근하지 못하도록 하는 설정 추가
- `application.yaml` 확인
- `false`로 두면 접근 불가
- 현재는 `true`로 열어두었음.

