### PR TITLE
[BUG] 픽 태그 리스트 수정 시 데드락 문제 수정

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -112,7 +112,7 @@ public class PickApiController {
 	})
 	public ResponseEntity<PickApiResponse.Pick> savePick(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Create request) {
-		if (request.title().length() > 200) {
+		if (!Objects.isNull(request.title()) && 200 < request.title().length()) {
 			throw ApiPickException.PICK_TITLE_TOO_LONG();
 		}
 

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickService.java
@@ -78,7 +78,6 @@ public class PickService {
 		return pickMapper.toPickResult(pickDataHandler.savePick(command));
 	}
 
-	@Transactional
 	public PickResult.Pick updatePick(PickCommand.Update command) {
 		validatePickAccess(command.userId(), command.id());
 		validateFolderAccess(command.userId(), command.parentFolderId());


### PR DESCRIPTION
- Close #512 

## What is this PR? 🔍

- 기능 : 픽 태그 리스트 수정 시 데드락 문제 수정
- issue : #512

## Changes 📝
- 개발 서버에서 테스트를 위한 PR입니다.
- PickService의 updatePick 트랜잭션 제거
- 픽 생성 시 null에 대한 length() 호출 방지

## TODO
- 데드락 문제 해결되지 않을 시 비관적 락 도입 예정