### PR TITLE
[FIX] 검색 픽 중복 표시

### DIFF
--- a/frontend/techpick/src/app/(signed)/folders/search/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { PickListViewerInfiniteScroll } from '@/components/PickListViewer/PickListViewerInfiniteScroll';
 import { usePickStore } from '@/stores/pickStore/pickStore';
@@ -10,21 +10,25 @@ export default function SearchPickResultPage() {
   const searchParams = useSearchParams();
   const { getSearchResult, searchPicksByQueryParam } = usePickStore();
   const [pickList, setPickList] = useState<PickListType>([]);
+  const isLoadFirst = useRef(true);
 
-  useEffect(() => {
-    setPickList([]);
-    (async () => {
-      await loadNextSlice();
-    })(/*IIFE*/);
-  }, [searchParams]);
-
-  const loadNextSlice = async () => {
+  const loadNextSlice = useCallback(async () => {
     await searchPicksByQueryParam(
       searchParams.toString(),
       getSearchResult().lastCursor
     );
     setPickList((prev) => prev.concat(getSearchResult().content));
-  };
+  }, [getSearchResult, searchParams, searchPicksByQueryParam]);
+
+  useEffect(() => {
+    if (isLoadFirst.current) {
+      isLoadFirst.current = false;
+      setPickList([]);
+      (async () => {
+        await loadNextSlice();
+      })(/*IIFE*/);
+    }
+  }, [loadNextSlice, searchParams]);
 
   return (
     <PickListViewerInfiniteScroll


### PR DESCRIPTION
- Close #517 

## What is this PR? 🔍

- 기능 :
최초 로드시에 픽 중복 검색 막았습니다.
디자인의 경우 다른 곳을 먼저 변경한 뒤에 검색 작업이 수행됩니다.
- issue : #517 

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
