### PR TITLE
[REFACTOR] PickTag 테이블에 낙관적 락 설정

### DIFF
--- a/backend/techpick-api/build.gradle
+++ b/backend/techpick-api/build.gradle
@@ -12,6 +12,9 @@ repositories {
 dependencies {
     implementation project(":techpick-core")
 
+    // Spring Retry 의존성 추가
+    implementation 'org.springframework.retry:spring-retry'
+
     // spring security and oauth client
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -192,7 +192,8 @@ public class PickDataHandler {
 
 	@Transactional
 	public void detachTagFromPickTag(Pick pick, Long tagId) {
-		pickTagRepository.deleteByPickAndTagId(pick, tagId);
+		pickTagRepository.findByPickAndTagId(pick, tagId)
+			.ifPresent(pickTag -> pickTagRepository.deleteByPickAndTagId(pick, tagId));
 	}
 
 	// 부모 폴더의 픽 리스트에 추가

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickDataHandler.java
@@ -3,6 +3,9 @@ package techpick.api.infrastructure.pick;
 import java.util.Comparator;
 import java.util.List;
 
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -115,6 +118,11 @@ public class PickDataHandler {
 	 * 부모 폴더 픽 리스트에서 pick 제거 후
 	 * 이동하는 폴더 픽 리스트에 pick 추가
 	 */
+	@Retryable(
+		value = {ObjectOptimisticLockingFailureException.class},
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 100)
+	)
 	@Transactional
 	public Pick updatePick(PickCommand.Update command) {
 		Pick pick = getPick(command.id());

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTag.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTag.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,6 +36,8 @@ public class PickTag {
 	@JoinColumn(name = "tag_id", nullable = false)
 	private Tag tag;
 
+	@Version
+	private Integer version;
 	// TODO: 엔티티 사용자가 정적 팩토리 메소드로 필요한 함수를 구현 하세요
 
 	private PickTag(Pick pick, Tag tag) {

--- a/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTagRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/pick/PickTagRepository.java
@@ -1,6 +1,7 @@
 package techpick.core.model.pick;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,8 @@ public interface PickTagRepository extends JpaRepository<PickTag, Long> {
 	List<PickTag> findAllByPickId(Long pickId);
 
 	List<PickTag> findAllByTagId(Long tagId);
+
+	Optional<PickTag> findByPickAndTagId(Pick pick, Long tagId);
 
 	void deleteByPick(Pick pick);
 


### PR DESCRIPTION
- Close #512

## What is this PR? 🔍

- 기능 : PickTag 테이블에 낙관적 락 설정
- issue : #512

## Changes 📝
- 개발 서버에서 테스트를 위해 PickTag 테이블에 낙관적 락 설정
- 픽의 태그 삭제 시 `ObjectOptimisticLockingFailureException` 발생하여 낙관적 락 설정하고자 함.
