### PR TITLE
[DESIGN] TagAutocompleteDialog 위치 조정

### DIFF
--- a/frontend/techpick/src/components/TagPicker/TagAutocompleteDialog.tsx
+++ b/frontend/techpick/src/components/TagPicker/TagAutocompleteDialog.tsx
@@ -42,7 +42,7 @@ export function TagAutocompleteDialog({
   const isCreateFetchPendingRef = useRef<boolean>(false);
   const randomNumber = useRef<number>(getRandomInt());
   const tagIdOrderedList = selectedTagList.map((tag) => tag.id);
-  const { refs, floatingStyles } = useFloating({
+  const { refs, floatingStyles, update } = useFloating({
     middleware: [
       flip({
         fallbackAxisSideDirection: 'start',
@@ -69,7 +69,7 @@ export function TagAutocompleteDialog({
     }
 
     const newTagIdOrderedList = [...tagIdOrderedList, tag.id];
-
+    update();
     focusTagInput();
     clearTagInputValue();
     updatePickInfo(pickInfo.parentFolderId, {
@@ -127,7 +127,10 @@ export function TagAutocompleteDialog({
             <SelectedTagItem key={tag.id} tag={tag}>
               <DeselectTagButton
                 tag={tag}
-                onClick={focusTagInput}
+                onClick={() => {
+                  focusTagInput();
+                  update();
+                }}
                 pickInfo={pickInfo}
                 selectedTagList={selectedTagList}
               />


### PR DESCRIPTION
- Close #ISSUE_NUMBER

## What is this PR? 🔍

- 기능 :
- issue : #

## Changes 📝
- 태그 선택이나 선택된 태그 삭제 시에 TagAutocompleteDialog의 위치를 조정하게 했습니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
