### PR TITLE
[FEAT] 해당 링크의 Og 태그 데이터 가져오는 API 구현

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/link/controller/LinkApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/link/controller/LinkApiController.java
@@ -1,0 +1,40 @@
+package techpick.api.application.link.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import techpick.api.application.link.dto.LinkApiMapper;
+import techpick.api.application.link.dto.LinkApiResponse;
+import techpick.api.domain.link.dto.LinkResult;
+import techpick.api.domain.link.service.LinkService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/links")
+@Tag(name = "Link API", description = "링크 API")
+public class LinkApiController {
+
+	private final LinkService linkService;
+	private final LinkApiMapper linkApiMapper;
+
+	@GetMapping
+	@Operation(summary = "해당 링크 og 데이터 조회", description = "해당 링크의 og 태그 데이터를 스크래핑을 통해 가져옵니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
+	public ResponseEntity<LinkApiResponse> getLinkData(
+		@Parameter(description = "og 태그 데이터 가져올 url") @RequestParam String url
+	) {
+		LinkResult linkResult = linkService.getUpdateOgTag(url);
+		return ResponseEntity.ok(linkApiMapper.toLinkResult(linkResult));
+	}
+}

--- a/backend/techpick-api/src/main/java/techpick/api/application/link/dto/LinkApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/link/dto/LinkApiMapper.java
@@ -1,0 +1,17 @@
+package techpick.api.application.link.dto;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import techpick.api.domain.link.dto.LinkResult;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface LinkApiMapper {
+
+	LinkApiResponse toLinkResult(LinkResult linkResult);
+}

--- a/backend/techpick-api/src/main/java/techpick/api/application/link/dto/LinkApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/link/dto/LinkApiResponse.java
@@ -1,0 +1,8 @@
+package techpick.api.application.link.dto;
+
+public record LinkApiResponse(
+	String title,
+	String description,
+	String imageUrl
+) {
+}

--- a/backend/techpick-api/src/main/java/techpick/api/domain/link/dto/LinkMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/link/dto/LinkMapper.java
@@ -21,4 +21,6 @@ public interface LinkMapper {
 	Link of(LinkInfo linkInfo);
 
 	LinkInfo of(Link link);
+
+	LinkResult toLinkResult(Link link);
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/link/dto/LinkResult.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/link/dto/LinkResult.java
@@ -1,0 +1,8 @@
+package techpick.api.domain.link.dto;
+
+public record LinkResult(
+	String title,
+	String description,
+	String imageUrl
+) {
+}


### PR DESCRIPTION
- Close #507 

## What is this PR? 🔍

- 기능 : 해당 링크의 Og 태그 데이터 가져오는 API 구현
- issue : #507

## Changes 📝
- 해당 링크의 Og 태그 데이터 가져오는 API 구현
- 링크에 대한 부분이므로 `LinkApiController`에 API 구현
