### PR TITLE
[BUG] 부모 폴더 삭제 Folder 엔티티 내부 메서드 활용하도록 변경

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -130,7 +130,7 @@ public class FolderDataHandler {
 				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 			Folder parentFolder = folder.getParentFolder();
-			parentFolder.getChildFolderIdOrderedList().remove(folder.getId());
+			parentFolder.removeChildFolderIdOrdered(folder.getId());
 
 			deleteList.add(folder);
 		}

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
@@ -152,6 +152,10 @@ public class Folder extends BaseEntity {
 		childPickIdOrderedList.remove(pickId);
 	}
 
+	public void removeChildFolderIdOrdered(Long folderId) {
+		childFolderIdOrderedList.remove(folderId);
+	}
+
 	@Builder
 	private Folder(
 		String name,


### PR DESCRIPTION
- Close #574

## What is this PR? 🔍

- 기능 : 폴더 삭제 Folder 엔티티 내부 메서드 활용하도록 변경
- issue : #574

## Changes 📝
- FolderDataHandler의 폴더 삭제 메서드에서 부모 폴더 삭제하는 부분 폴더 내부 메서드 사용하도록 변경