### PR TITLE
[FIX] @MeasureTime 어노테이션 버그 수정

### DIFF
--- a/backend/techpick-core/src/main/java/techpick/core/util/MeasureTimeAspect.java
+++ b/backend/techpick-core/src/main/java/techpick/core/util/MeasureTimeAspect.java
@@ -6,24 +6,29 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class MeasureTimeAspect {
+
+	private final RequestHolder requestHolder;
 
 	@Pointcut("@annotation(techpick.core.annotation.MeasureTime)")
 	public void pointcut() {
 	}
 
 	@Around("pointcut()")
-	public void around(ProceedingJoinPoint joinPoint) throws Throwable {
+	public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
 		var methodName = joinPoint.getSignature().getName();
 		// 필요하다면 StopWatch 클래스 도입 고려
 		long startTime = System.currentTimeMillis();
-		joinPoint.proceed();
+		var result = joinPoint.proceed();
 		long endTime = System.currentTimeMillis();
-		log.info("{} 실행 시간 : {} ms", methodName, endTime - startTime);
+		log.info("{} 실행 시간 : {} ms \n request : {} ", methodName, endTime - startTime, requestHolder.getRequest());
+		return result;
 	}
 }


### PR DESCRIPTION
- Close #573

## What is this PR? 🔍

- 기능 : @MeasureTime 어노테이션 버그 수정
- issue : #573

## Changes 📝

### `@MeasureTime` 어노테이션 적용 시 반환값이 사라지는 버그 수정
- 원인 : 반환 타입이 `void`로 되어있어 반환값이 컨트롤러로 넘어가지 않음
```
@Around("pointcut()")
public void around(ProceedingJoinPoint joinPoint) throws Throwable {
	var methodName = joinPoint.getSignature().getName();
	// 필요하다면 StopWatch 클래스 도입 고려
	long startTime = System.currentTimeMillis();
	joinPoint.proceed();
	long endTime = System.currentTimeMillis();
	log.info("{} 실행 시간 : {} ms", methodName, endTime - startTime,);
}
```
- 수정 : 반환값을 `Object`타입으로 반환
```
@Around("pointcut()")
public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
	var methodName = joinPoint.getSignature().getName();
	// 필요하다면 StopWatch 클래스 도입 고려
	long startTime = System.currentTimeMillis();
	var result = joinPoint.proceed();
	long endTime = System.currentTimeMillis();
	log.info("{} 실행 시간 : {} ms \n request : {} ", methodName, endTime - startTime, requestHolder.getRequest());
	return result;
}
```

### 로깅 항목 추가 - 요청 정보
`log.info("{} 실행 시간 : {} ms \n request : {} ", methodName, endTime - startTime, requestHolder.getRequest())`
