### PR TITLE
[BUG] 부모 폴더 내에 있는 하위 폴더 리스트 업데이트 문제

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -74,7 +74,7 @@ public class FolderDataHandler {
 	@Transactional
 	public Folder saveFolder(FolderCommand.Create command) {
 		User user = userRepository.findById(command.userId()).orElseThrow(ApiUserException::USER_NOT_FOUND);
-		Folder parentFolder = folderRepository.findById(command.parentFolderId())
+		Folder parentFolder = folderRepository.findByIdForUpdate(command.parentFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 		Folder folder = folderRepository.save(Folder.createEmptyGeneralFolder(user, parentFolder, command.name()));
@@ -93,7 +93,7 @@ public class FolderDataHandler {
 
 	@Transactional
 	public List<Long> moveFolderWithinParent(FolderCommand.Move command) {
-		Folder parentFolder = folderRepository.findById(command.parentFolderId())
+		Folder parentFolder = folderRepository.findByIdForUpdate(command.parentFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 		parentFolder.updateChildFolderIdOrderedList(command.idList(), command.orderIdx());
@@ -102,13 +102,13 @@ public class FolderDataHandler {
 
 	@Transactional
 	public List<Long> moveFolderToDifferentParent(FolderCommand.Move command) {
-		Folder folder = folderRepository.findById(command.idList().get(0))
+		Folder folder = folderRepository.findByIdForUpdate(command.idList().get(0))
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 		Folder oldParent = folder.getParentFolder();
 		oldParent.getChildFolderIdOrderedList().removeAll(command.idList());
 
-		Folder newParent = folderRepository.findById(command.destinationFolderId())
+		Folder newParent = folderRepository.findByIdForUpdate(command.destinationFolderId())
 			.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 		newParent.addChildFolderIdOrderedList(command.idList(), command.orderIdx());
 
@@ -126,7 +126,7 @@ public class FolderDataHandler {
 		List<Folder> deleteList = new ArrayList<>();
 
 		for (Long id : command.idList()) {
-			Folder folder = folderRepository.findById(id)
+			Folder folder = folderRepository.findByIdForUpdate(id)
 				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 			Folder parentFolder = folder.getParentFolder();

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/folder/FolderDataHandler.java
@@ -130,7 +130,7 @@ public class FolderDataHandler {
 				.orElseThrow(ApiFolderException::FOLDER_NOT_FOUND);
 
 			Folder parentFolder = folder.getParentFolder();
-			parentFolder.getChildFolderIdOrderedList().remove(folder.getId());
+			parentFolder.removeChildFolderIdOrdered(folder.getId());
 
 			deleteList.add(folder);
 		}

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/Folder.java
@@ -152,6 +152,10 @@ public class Folder extends BaseEntity {
 		childPickIdOrderedList.remove(pickId);
 	}
 
+	public void removeChildFolderIdOrdered(Long folderId) {
+		childFolderIdOrderedList.remove(folderId);
+	}
+
 	@Builder
 	private Folder(
 		String name,

--- a/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
+++ b/backend/techpick-core/src/main/java/techpick/core/model/folder/FolderRepository.java
@@ -1,12 +1,25 @@
 package techpick.core.model.folder;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+	@Lock(value = LockModeType.PESSIMISTIC_WRITE)
+	@QueryHints({
+		@QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+	})
+	@Query("SELECT f FROM Folder f WHERE f.id=:id")
+	Optional<Folder> findByIdForUpdate(Long id);
 
 	List<Folder> findByUserId(Long userId);
 	


### PR DESCRIPTION
- Close #574
## What is this PR? 🔍

- 기능 : 부모 폴더 내에 있는 하위 폴더 리스트 업데이트 문제
- issue : #574

## Changes 📝
- `부모 폴더를 조회`하는 부분에서 `동시성 문제가 발생`한다고 판단하였음.
- 부모 폴더에 있는 하위 폴더 리스트 삭제, 생성 요청이 동시에 처리 될 때 문제가 발생한다고 판단함.
- 부모 폴더 조회 시에 `비관적 락을 적용`시켜 동시성 문제를 해결해보고자 함.