### PR TITLE
[FEAT] 페이지네이션 적용되지 않은 검색 API 구현

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -3,10 +3,12 @@ package techpick.api.application.pick.controller;
 import java.util.List;
 import java.util.Objects;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,14 +70,10 @@ public class PickApiController {
 	})
 	public ResponseEntity<PickSliceResponse<PickApiResponse.Pick>> searchPickPagination(
 		@LoginUserId Long userId,
-		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> folderIdList,
-		@Parameter(description = "검색 토큰 목록", example = "리액트, 쿼리, 서버") @RequestParam(required = false, defaultValue = "") List<String> searchTokenList,
-		@Parameter(description = "검색 태그 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> tagIdList,
-		@Parameter(description = "픽 시작 id 조회", example = "0") @RequestParam(required = false, defaultValue = "0") Long cursor,
-		@Parameter(description = "한 페이지에 가져올 픽 개수", example = "20") @RequestParam(required = false, defaultValue = "20") int size
+		@ParameterObject @ModelAttribute PickApiRequest.SearchPagination request
 	) {
 		Slice<PickResult.Pick> pickResultList = pickSearchService.searchPickPagination(
-			pickApiMapper.toSearchPaginationCommand(userId, folderIdList, searchTokenList, tagIdList, cursor, size));
+			pickApiMapper.toSearchPaginationCommand(userId, request));
 
 		return ResponseEntity.ok(new PickSliceResponse<>(pickApiMapper.toSliceApiResponse(pickResultList)));
 	}
@@ -87,12 +85,10 @@ public class PickApiController {
 	})
 	public ResponseEntity<List<PickApiResponse.Pick>> searchPick(
 		@LoginUserId Long userId,
-		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> folderIdList,
-		@Parameter(description = "검색 토큰 목록", example = "리액트, 쿼리, 서버") @RequestParam(required = false, defaultValue = "") List<String> searchTokenList,
-		@Parameter(description = "검색 태그 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> tagIdList
+		@ParameterObject @ModelAttribute PickApiRequest.Search request
 	) {
 		List<PickResult.Pick> pickList = pickSearchService.searchPick(
-			pickApiMapper.toSearchCommand(userId, folderIdList, searchTokenList, tagIdList));
+			pickApiMapper.toSearchCommand(userId, request));
 
 		List<PickApiResponse.Pick> pickResponseList = pickList.stream()
 			.map(pickApiMapper::toApiResponse)

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -66,7 +66,7 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
-	public ResponseEntity<PickSliceResponse<PickApiResponse.Pick>> searchPick(
+	public ResponseEntity<PickSliceResponse<PickApiResponse.Pick>> searchPickPagination(
 		@LoginUserId Long userId,
 		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> folderIdList,
 		@Parameter(description = "검색 토큰 목록", example = "리액트, 쿼리, 서버") @RequestParam(required = false, defaultValue = "") List<String> searchTokenList,
@@ -85,7 +85,7 @@ public class PickApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공")
 	})
-	public ResponseEntity<List<PickApiResponse.Pick>> searchPickWithoutPagination(
+	public ResponseEntity<List<PickApiResponse.Pick>> searchPick(
 		@LoginUserId Long userId,
 		@Parameter(description = "조회할 폴더 ID 목록", example = "1, 2, 3") @RequestParam(required = false, defaultValue = "") List<Long> folderIdList,
 		@Parameter(description = "검색 토큰 목록", example = "리액트, 쿼리, 서버") @RequestParam(required = false, defaultValue = "") List<String> searchTokenList,

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiMapper.java
@@ -25,6 +25,9 @@ public interface PickApiMapper {
 	PickCommand.ReadList toReadListCommand(Long userId, List<Long> folderIdList);
 
 	PickCommand.Search toSearchCommand(Long userId, List<Long> folderIdList, List<String> searchTokenList,
+		List<Long> tagIdList);
+
+	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, List<Long> folderIdList, List<String> searchTokenList,
 		List<Long> tagIdList, Long cursor, int size);
 
 	PickCommand.Create toCreateCommand(Long userId, PickApiRequest.Create request);

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiMapper.java
@@ -24,11 +24,9 @@ public interface PickApiMapper {
 
 	PickCommand.ReadList toReadListCommand(Long userId, List<Long> folderIdList);
 
-	PickCommand.Search toSearchCommand(Long userId, List<Long> folderIdList, List<String> searchTokenList,
-		List<Long> tagIdList);
+	PickCommand.Search toSearchCommand(Long userId, PickApiRequest.Search request);
 
-	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, List<Long> folderIdList, List<String> searchTokenList,
-		List<Long> tagIdList, Long cursor, int size);
+	PickCommand.SearchPagination toSearchPaginationCommand(Long userId, PickApiRequest.SearchPagination request);
 
 	PickCommand.Create toCreateCommand(Long userId, PickApiRequest.Create request);
 

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiRequest.java
@@ -21,6 +21,25 @@ public class PickApiRequest {
 	) {
 	}
 
+	public record Search(
+		@Schema(description = "조회할 폴더 ID 목록", example = "3, 4, 5") List<Long> folderIdList,
+		@Schema(description = "검색 토큰 목록", example = "Record, 스프링") List<String> searchTokenList,
+		@Schema(description = "검색 태그 ID 목록", example = "1, 2, 3") List<Long> tagIdList
+	) {
+	}
+
+	public record SearchPagination(
+		@Schema(description = "조회할 폴더 ID 목록", example = "3, 4, 5") List<Long> folderIdList,
+		@Schema(description = "검색 토큰 목록", example = "Record, 스프링") List<String> searchTokenList,
+		@Schema(description = "검색 태그 ID 목록", example = "1, 2, 3") List<Long> tagIdList,
+		@Schema(description = "픽 시작 id 조회", example = "0", defaultValue = "0") Long cursor,
+		@Schema(description = "한 페이지에 가져올 픽 개수", example = "20", defaultValue = "20") Integer size
+	) {
+		public Integer size() {
+			return size == null || size <= 0 ? 20 : size;
+		}
+	}
+
 	public record Update(
 		@Schema(example = "1") @NotNull(message = "{id.notNull}") Long id,
 		@Schema(example = "Record란 뭘까?") String title,

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/dto/PickCommand.java
@@ -13,6 +13,10 @@ public class PickCommand {
 	}
 
 	public record Search(Long userId, List<Long> folderIdList, List<String> searchTokenList,
+						 List<Long> tagIdList) {
+	}
+
+	public record SearchPagination(Long userId, List<Long> folderIdList, List<String> searchTokenList,
 						 List<Long> tagIdList, Long cursor, int size) {
 	}
 

--- a/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickSearchService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/pick/service/PickSearchService.java
@@ -30,7 +30,7 @@ public class PickSearchService {
 	private final TagDataHandler tagDataHandler;
 
 	@Transactional(readOnly = true)
-	public Slice<PickResult.Pick> searchPick(PickCommand.Search command) {
+	public Slice<PickResult.Pick> searchPickPagination(PickCommand.SearchPagination command) {
 		List<Long> folderIdList = command.folderIdList();
 		List<Long> tagIdList = command.tagIdList();
 
@@ -47,9 +47,30 @@ public class PickSearchService {
 			}
 		}
 
-		return pickQuery.searchPick(command.userId(), folderIdList,
+		return pickQuery.searchPickPagination(command.userId(), folderIdList,
 			command.searchTokenList(), command.tagIdList(),
 			command.cursor(), command.size());
+	}
+
+	@Transactional(readOnly = true)
+	public List<PickResult.Pick> searchPick(PickCommand.Search command) {
+		List<Long> folderIdList = command.folderIdList();
+		List<Long> tagIdList = command.tagIdList();
+
+		if (ObjectUtils.isNotEmpty(folderIdList)) {
+			for (Long folderId : folderIdList) {
+				validateFolderAccess(command.userId(), folderId);
+				validateFolderRootSearch(folderId);
+			}
+		}
+
+		if (ObjectUtils.isNotEmpty(tagIdList)) {
+			for (Long tagId : tagIdList) {
+				validateTagAccess(command.userId(), tagId);
+			}
+		}
+
+		return pickQuery.searchPick(command.userId(), folderIdList, command.searchTokenList(), command.tagIdList());
 	}
 
 	private void validateFolderAccess(Long userId, Long folderId) {

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickQuery.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/pick/PickQuery.java
@@ -68,8 +68,25 @@ public class PickQuery {
 			.fetch();
 	}
 
+	public List<PickResult.Pick> searchPick(Long userId, List<Long> folderIdList, List<String> searchTokenList,
+		List<Long> tagIdList) {
+
+		return jpaQueryFactory
+			.select(pickResultFields()) // dto로 반환
+			.from(pick)
+			.leftJoin(pickTag).on(pick.id.eq(pickTag.pick.id))
+			.where(
+				userEqCondition(userId), // 본인 pick 조회
+				folderIdCondition(folderIdList), // 폴더에 해당 하는 pick 조회
+				searchTokenListCondition(searchTokenList), // 제목 검색 조건
+				tagIdListCondition(tagIdList) // 태그 검색 조건
+			)
+			.distinct()
+			.fetch();
+	}
+
 	// TODO: 본인 픽이 아닌 다른 사람의 픽도 검색하고 싶다면 userId 부분 제거
-	public Slice<PickResult.Pick> searchPick(Long userId, List<Long> folderIdList, List<String> searchTokenList,
+	public Slice<PickResult.Pick> searchPickPagination(Long userId, List<Long> folderIdList, List<String> searchTokenList,
 		List<Long> tagIdList, Long cursor, int size) {
 
 		List<PickResult.Pick> pickList = jpaQueryFactory

--- a/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickSearchTest.java
+++ b/backend/techpick-api/src/test/java/techpick/api/domain/pick/service/PickSearchTest.java
@@ -69,7 +69,7 @@ class PickSearchTest {
 	@MethodSource("provideSearchTestCases")
 	void parameterizedSearchTest(TestCase testCase) {
 		// given
-		PickCommand.Search search = new PickCommand.Search(
+		PickCommand.SearchPagination search = new PickCommand.SearchPagination(
 			user1.getId(),
 			testCase.folderIdList,
 			testCase.searchTokenList,
@@ -79,7 +79,7 @@ class PickSearchTest {
 		);
 
 		// when
-		Slice<PickResult.Pick> pickList = pickSearchService.searchPick(search);
+		Slice<PickResult.Pick> pickList = pickSearchService.searchPickPagination(search);
 
 		// then
 		assertThat(pickList).isNotNull();
@@ -150,7 +150,7 @@ class PickSearchTest {
 		@MethodSource("provideTestCases")
 		void parameterizedTitleSearchTest(TestCase testCase) {
 			// given
-			PickCommand.Search search = new PickCommand.Search(
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(
 				user1.getId(),
 				testCase.folderIdList,
 				testCase.searchTokenList,
@@ -160,7 +160,7 @@ class PickSearchTest {
 			);
 
 			// when
-			Slice<PickResult.Pick> pickList = pickSearchService.searchPick(search);
+			Slice<PickResult.Pick> pickList = pickSearchService.searchPickPagination(search);
 
 			// then
 			assertThat(pickList).isNotNull();
@@ -190,11 +190,11 @@ class PickSearchTest {
 			List<String> searchTokenList = null;
 			List<Long> tagIdList = null;
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when, then
-			assertThatThrownBy(() -> pickSearchService.searchPick(search))
+			assertThatThrownBy(() -> pickSearchService.searchPickPagination(search))
 				.isInstanceOf(ApiFolderException.class)
 				.hasMessageStartingWith(ApiFolderException.ROOT_FOLDER_SEARCH_NOT_ALLOWED().getMessage());
 		}
@@ -203,7 +203,7 @@ class PickSearchTest {
 		@MethodSource("provideFolderSearchTestCases")
 		void parameterizedFolderSearchTest(TestCase testCase) {
 			// given
-			PickCommand.Search search = new PickCommand.Search(
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(
 				user1.getId(),
 				testCase.folderIdList,
 				testCase.searchTokenList,
@@ -213,7 +213,7 @@ class PickSearchTest {
 			);
 
 			// when
-			Slice<PickResult.Pick> pickList = pickSearchService.searchPick(search);
+			Slice<PickResult.Pick> pickList = pickSearchService.searchPickPagination(search);
 
 			// then
 			assertThat(pickList).isNotNull();
@@ -246,7 +246,7 @@ class PickSearchTest {
 		@MethodSource("provideTagSearchTestCases")
 		void parameterizedTagSearchTest(TestCase testCase) {
 			// given
-			PickCommand.Search search = new PickCommand.Search(
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(
 				user1.getId(),
 				testCase.folderIdList,
 				testCase.searchTokenList,
@@ -256,7 +256,7 @@ class PickSearchTest {
 			);
 
 			// when
-			Slice<PickResult.Pick> pickList = pickSearchService.searchPick(search);
+			Slice<PickResult.Pick> pickList = pickSearchService.searchPickPagination(search);
 
 			// then
 			assertThat(pickList).isNotNull();
@@ -295,11 +295,11 @@ class PickSearchTest {
 			List<String> searchTokenList = null;
 			List<Long> tagIdList = null;
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when, then
-			assertThatThrownBy(() -> pickSearchService.searchPick(search))
+			assertThatThrownBy(() -> pickSearchService.searchPickPagination(search))
 				.isInstanceOf(ApiFolderException.class)
 				.hasMessageStartingWith(ApiFolderException.FOLDER_NOT_FOUND().getMessage());
 		}
@@ -312,11 +312,11 @@ class PickSearchTest {
 			List<String> searchTokenList = List.of("검색결과가없음");
 			List<Long> tagIdList = null;
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when
-			Slice<PickResult.Pick> pickList = pickSearchService.searchPick(search);
+			Slice<PickResult.Pick> pickList = pickSearchService.searchPickPagination(search);
 
 			// then
 			assertThat(pickList).isNotNull();
@@ -331,11 +331,11 @@ class PickSearchTest {
 			List<String> searchTokenList = List.of("검색결과가없음");
 			List<Long> tagIdList = List.of(999L);
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when, then
-			assertThatThrownBy(() -> pickSearchService.searchPick(search))
+			assertThatThrownBy(() -> pickSearchService.searchPickPagination(search))
 				.isInstanceOf(ApiTagException.class)
 				.hasMessageStartingWith(ApiTagException.TAG_NOT_FOUND().getMessage());
 		}
@@ -348,11 +348,11 @@ class PickSearchTest {
 			List<String> searchTokenList = null;
 			List<Long> tagIdList = null;
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when, then
-			assertThatThrownBy(() -> pickSearchService.searchPick(search))
+			assertThatThrownBy(() -> pickSearchService.searchPickPagination(search))
 				.isInstanceOf(ApiFolderException.class)
 				.hasMessageStartingWith(ApiFolderException.FOLDER_ACCESS_DENIED().getMessage());
 		}
@@ -365,11 +365,11 @@ class PickSearchTest {
 			List<String> searchTokenList = null;
 			List<Long> tagIdList = List.of(tag4.getId());
 
-			PickCommand.Search search = new PickCommand.Search(user1.getId(), folderIdList, searchTokenList, tagIdList,
+			PickCommand.SearchPagination search = new PickCommand.SearchPagination(user1.getId(), folderIdList, searchTokenList, tagIdList,
 				0L, 30);
 
 			// when, then
-			assertThatThrownBy(() -> pickSearchService.searchPick(search))
+			assertThatThrownBy(() -> pickSearchService.searchPickPagination(search))
 				.isInstanceOf(ApiTagException.class)
 				.hasMessageStartingWith(ApiTagException.UNAUTHORIZED_TAG_ACCESS().getMessage());
 		}


### PR DESCRIPTION
- Close #586

## What is this PR? 🔍

- 기능 : 페이지네이션 적용되지 않은 검색 API 구현
- issue : #586

## Changes 📝
### 구현 이유
태그 검색 조차 없기 때문에 적어도 태그는 필터링할 수 있도록 하기 위해서 API 구현
페이지네이션을 적용되지 않은 API 구현 이유는 프론트 쪽 무한 스크롤 관련 에러 처리가 시간 소요가 크기 때문

- 페이지네이션 적용되지 않은 API 구현
  - `/api/picks/search/all` : 페이지네이션 처리x
  - `/api/picks/search` : 페이지네이션 처리

- 페이지네이션 처리된 부분과 아닌 부분 메서드, 변수명 변경
  - `searchPick` : 페이지네이션 처리x
  - `searchPickPagination` : 페이지네이션 처리