### PR TITLE
[REFACTOR]  SharedFolder 리팩토링

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/sharedFolder/controller/SharedFolderApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/sharedFolder/controller/SharedFolderApiController.java
@@ -40,7 +40,7 @@ public class SharedFolderApiController {
 		@ApiResponse(responseCode = "200", description = "공유폴더 생성 성공"),
 		@ApiResponse(responseCode = "403", description = "자신의 폴더만 공유할 수 있습니다.")
 	})
-	public ResponseEntity<SharedFolderResult.Folder> createSharedFolder(@LoginUserId Long userId,
+	public ResponseEntity<SharedFolderResult.Create> createSharedFolder(@LoginUserId Long userId,
 		@Valid @RequestBody SharedFolderApiRequest.Create request) throws
 		JsonProcessingException {
 		var result = sharedFolderService.createSharedFolder(

--- a/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/dto/SharedFolderMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/dto/SharedFolderMapper.java
@@ -1,6 +1,7 @@
 package techpick.api.domain.sharedFolder.dto;
 
 import java.util.ArrayList;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -54,5 +55,9 @@ public class SharedFolderMapper {
 		return SharedFolderResult.List.builder()
 			.uuid(sharedFolder.getId())
 			.build();
+	}
+
+	public SharedFolderResult.Create toCreateResult(UUID uuid, FolderNode folderNode) {
+		return SharedFolderResult.Create.builder().uuid(uuid).folderNode(folderNode).build();
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/dto/SharedFolderResult.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/dto/SharedFolderResult.java
@@ -7,6 +7,10 @@ import lombok.Builder;
 public class SharedFolderResult {
 
 	@Builder
+	public record Create(UUID uuid, FolderNode folderNode) {
+	}
+
+	@Builder
 	public record Folder(UUID uuid, String jsonData) {
 	}
 

--- a/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/service/SharedFolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/sharedFolder/service/SharedFolderService.java
@@ -40,7 +40,7 @@ public class SharedFolderService {
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Transactional
-	public SharedFolderResult.Folder createSharedFolder(SharedFolderCommand.Create command) throws
+	public SharedFolderResult.Create createSharedFolder(SharedFolderCommand.Create command) throws
 		JsonProcessingException {
 		LocalDateTime now = LocalDateTime.now();
 		// 공유할 폴더들을 하나로 묶기 위한 가상의 최상위 폴더를 생성
@@ -57,8 +57,8 @@ public class SharedFolderService {
 		}
 
 		String jsonData = objectMapper.writeValueAsString(root);
-
-		return sharedFolderMapper.toResultFolder(sharedFolderDataHandler.save(command.userId(), jsonData, now));
+		var saved = sharedFolderDataHandler.save(command.userId(), jsonData, now);
+		return sharedFolderMapper.toCreateResult(saved.getId(), root);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
- Close #607

## What is this PR? 🔍

- 기능 : SharedFolder 리팩토링
- issue : #607

## Changes 📝

공유폴더에 대한 정보를 json으로 응답해서
해당 json에 대한 schema 정보가 존재하지 않음
이를위해 생성시에는 직렬화 이전의 dto를 내려보네 swagger에 schema 등록

등록된 스키마 목록
- `techpick.api.application.sharedFolder.dto.SharedFolderApiRequest$Create`
- `techpick.api.domain.sharedFolder.dto.FolderNode`
- `techpick.api.domain.sharedFolder.dto.PickNode`
- `techpick.api.domain.sharedFolder.dto.TagNode`


