### PR TITLE
[FEAT] pick 로딩중인지, 빈 값인지 확인하는 로직 추가

### DIFF
--- a/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
@@ -6,6 +6,7 @@ import { PickRecordHeader } from '@/components';
 import { EmptyPickRecordImage } from '@/components/EmptyPickRecordImage';
 import { FolderContentHeader } from '@/components/FolderContentHeader/FolderContentHeader';
 import { FolderContentLayout } from '@/components/FolderContentLayout';
+import { FolderLoadingPage } from '@/components/FolderLoadingPage';
 import { PickContentLayout } from '@/components/PickContentLayout';
 import { PickDraggableListLayout } from '@/components/PickDraggableListLayout';
 import { PickDraggableRecord } from '@/components/PickRecord/PickDraggableRecord';
@@ -54,7 +55,7 @@ export default function FolderDetailPage() {
   };
 
   if (!basicFolderMap || (isLoading && !data)) {
-    return <div>loading...</div>;
+    return <FolderLoadingPage />;
   }
 
   const pickList = getOrderedPickListByFolderId(data);

--- a/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
@@ -14,17 +14,20 @@ import {
   useResetPickFocusOnOutsideClick,
   useClearSelectedPickIdsOnMount,
   useFetchTagList,
+  useFetchPickRecordByFolderId,
 } from '@/hooks';
-import { usePickStore, useTreeStore } from '@/stores';
+import { useTreeStore } from '@/stores';
+import { getOrderedPickListByFolderId } from '@/utils';
 
 export default function FolderDetailPage() {
   const router = useRouter();
   const { folderId: stringFolderId } = useParams<{ folderId: string }>();
-  const { fetchPickDataByFolderId, getOrderedPickListByFolderId } =
-    usePickStore();
   const selectSingleFolder = useTreeStore((state) => state.selectSingleFolder);
   const folderId = Number(stringFolderId);
   const basicFolderMap = useTreeStore((state) => state.basicFolderMap);
+  const { isLoading, data } = useFetchPickRecordByFolderId({
+    folderId: folderId,
+  });
   useResetPickFocusOnOutsideClick();
   useClearSelectedPickIdsOnMount();
   useFetchTagList();
@@ -41,18 +44,6 @@ export default function FolderDetailPage() {
     [folderId, router, selectSingleFolder]
   );
 
-  useEffect(
-    function loadPickDataByFolderIdFromRemote() {
-      if (!isFolderIdValid(folderId)) {
-        router.replace(ROUTES.UNCLASSIFIED_FOLDER);
-        return;
-      }
-
-      fetchPickDataByFolderId(folderId);
-    },
-    [fetchPickDataByFolderId, folderId, router]
-  );
-
   const isFolderIdValid = (folderId: number) => {
     if (Number.isNaN(folderId)) {
       return false;
@@ -61,11 +52,11 @@ export default function FolderDetailPage() {
     return true;
   };
 
-  if (!basicFolderMap) {
+  if (!basicFolderMap || isLoading) {
     return <div>loading...</div>;
   }
 
-  const pickList = getOrderedPickListByFolderId(folderId);
+  const pickList = getOrderedPickListByFolderId(data);
 
   return (
     <FolderContentLayout>

--- a/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/[folderId]/page.tsx
@@ -27,6 +27,7 @@ export default function FolderDetailPage() {
   const basicFolderMap = useTreeStore((state) => state.basicFolderMap);
   const { isLoading, data } = useFetchPickRecordByFolderId({
     folderId: folderId,
+    alwaysFetch: true,
   });
   useResetPickFocusOnOutsideClick();
   useClearSelectedPickIdsOnMount();
@@ -52,7 +53,7 @@ export default function FolderDetailPage() {
     return true;
   };
 
-  if (!basicFolderMap || isLoading) {
+  if (!basicFolderMap || (isLoading && !data)) {
     return <div>loading...</div>;
   }
 

--- a/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
@@ -39,7 +39,7 @@ export default function RecycleBinFolderPage() {
     [basicFolderMap, selectSingleFolder]
   );
 
-  if (!basicFolderMap || isLoading) {
+  if (!basicFolderMap || (isLoading && !data)) {
     return <div>loading...</div>;
   }
 

--- a/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
@@ -5,6 +5,7 @@ import { PickRecordHeader } from '@/components';
 import { EmptyPickRecordImage } from '@/components/EmptyPickRecordImage';
 import { FolderContentHeader } from '@/components/FolderContentHeader/FolderContentHeader';
 import { FolderContentLayout } from '@/components/FolderContentLayout';
+import { FolderLoadingPage } from '@/components/FolderLoadingPage';
 import { PickContentLayout } from '@/components/PickContentLayout';
 import { PickDraggableListLayout } from '@/components/PickDraggableListLayout';
 import { PickDraggableRecord } from '@/components/PickRecord/PickDraggableRecord';
@@ -40,7 +41,7 @@ export default function RecycleBinFolderPage() {
   );
 
   if (!basicFolderMap || (isLoading && !data)) {
-    return <div>loading...</div>;
+    return <FolderLoadingPage />;
   }
 
   const pickList = getOrderedPickListByFolderId(data);

--- a/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/recycle-bin/page.tsx
@@ -10,16 +10,20 @@ import { PickDraggableListLayout } from '@/components/PickDraggableListLayout';
 import { PickDraggableRecord } from '@/components/PickRecord/PickDraggableRecord';
 import {
   useClearSelectedPickIdsOnMount,
+  useFetchPickRecordByFolderId,
   useFetchTagList,
   useResetPickFocusOnOutsideClick,
 } from '@/hooks';
-import { usePickStore, useTreeStore } from '@/stores';
+import { useTreeStore } from '@/stores';
+import { getOrderedPickListByFolderId } from '@/utils';
 
 export default function RecycleBinFolderPage() {
-  const { fetchPickDataByFolderId, getOrderedPickListByFolderId } =
-    usePickStore();
   const selectSingleFolder = useTreeStore((state) => state.selectSingleFolder);
   const basicFolderMap = useTreeStore((state) => state.basicFolderMap);
+  const { isLoading, data } = useFetchPickRecordByFolderId({
+    folderId: basicFolderMap?.RECYCLE_BIN.id,
+    alwaysFetch: true,
+  });
   useResetPickFocusOnOutsideClick();
   useClearSelectedPickIdsOnMount();
   useFetchTagList();
@@ -35,24 +39,11 @@ export default function RecycleBinFolderPage() {
     [basicFolderMap, selectSingleFolder]
   );
 
-  useEffect(
-    function loadPickDataFromRemote() {
-      if (!basicFolderMap) {
-        return;
-      }
-
-      fetchPickDataByFolderId(basicFolderMap['RECYCLE_BIN'].id);
-    },
-    [basicFolderMap, fetchPickDataByFolderId]
-  );
-
-  if (!basicFolderMap) {
+  if (!basicFolderMap || isLoading) {
     return <div>loading...</div>;
   }
 
-  const pickList = getOrderedPickListByFolderId(
-    basicFolderMap['RECYCLE_BIN'].id
-  );
+  const pickList = getOrderedPickListByFolderId(data);
 
   return (
     <FolderContentLayout>

--- a/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
@@ -12,15 +12,17 @@ import {
   useClearSelectedPickIdsOnMount,
   useFetchTagList,
   useResetPickFocusOnOutsideClick,
+  useFetchPickRecordByFolderId,
 } from '@/hooks';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
-import { usePickStore } from '@/stores/pickStore/pickStore';
+import { getOrderedPickListByFolderId } from '@/utils';
 
 export default function UnclassifiedFolderPage() {
-  const { fetchPickDataByFolderId, getOrderedPickListByFolderId } =
-    usePickStore();
   const selectSingleFolder = useTreeStore((state) => state.selectSingleFolder);
   const basicFolderMap = useTreeStore((state) => state.basicFolderMap);
+  const { isLoading, data } = useFetchPickRecordByFolderId({
+    folderId: basicFolderMap?.UNCLASSIFIED.id,
+  });
   useResetPickFocusOnOutsideClick();
   useClearSelectedPickIdsOnMount();
   useFetchTagList();
@@ -36,24 +38,11 @@ export default function UnclassifiedFolderPage() {
     [basicFolderMap, selectSingleFolder]
   );
 
-  useEffect(
-    function loadPickDataFromRemote() {
-      if (!basicFolderMap) {
-        return;
-      }
-
-      fetchPickDataByFolderId(basicFolderMap['UNCLASSIFIED'].id);
-    },
-    [basicFolderMap, fetchPickDataByFolderId]
-  );
-
-  if (!basicFolderMap) {
+  if (!basicFolderMap || isLoading) {
     return <div>loading...</div>;
   }
 
-  const pickList = getOrderedPickListByFolderId(
-    basicFolderMap['UNCLASSIFIED'].id
-  );
+  const pickList = getOrderedPickListByFolderId(data);
 
   return (
     <FolderContentLayout>

--- a/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
@@ -22,6 +22,7 @@ export default function UnclassifiedFolderPage() {
   const basicFolderMap = useTreeStore((state) => state.basicFolderMap);
   const { isLoading, data } = useFetchPickRecordByFolderId({
     folderId: basicFolderMap?.UNCLASSIFIED.id,
+    alwaysFetch: true,
   });
   useResetPickFocusOnOutsideClick();
   useClearSelectedPickIdsOnMount();
@@ -38,7 +39,7 @@ export default function UnclassifiedFolderPage() {
     [basicFolderMap, selectSingleFolder]
   );
 
-  if (!basicFolderMap || isLoading) {
+  if (!basicFolderMap || (isLoading && !data)) {
     return <div>loading...</div>;
   }
 

--- a/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
+++ b/frontend/techpick/src/app/(signed)/folders/unclassified/page.tsx
@@ -5,6 +5,7 @@ import { PickRecordHeader } from '@/components';
 import { EmptyPickRecordImage } from '@/components/EmptyPickRecordImage';
 import { FolderContentHeader } from '@/components/FolderContentHeader/FolderContentHeader';
 import { FolderContentLayout } from '@/components/FolderContentLayout';
+import { FolderLoadingPage } from '@/components/FolderLoadingPage';
 import { PickContentLayout } from '@/components/PickContentLayout';
 import { PickDraggableListLayout } from '@/components/PickDraggableListLayout';
 import { PickDraggableRecord } from '@/components/PickRecord/PickDraggableRecord';
@@ -40,7 +41,7 @@ export default function UnclassifiedFolderPage() {
   );
 
   if (!basicFolderMap || (isLoading && !data)) {
-    return <div>loading...</div>;
+    return <FolderLoadingPage />;
   }
 
   const pickList = getOrderedPickListByFolderId(data);

--- a/frontend/techpick/src/components/FolderLoadingPage.tsx
+++ b/frontend/techpick/src/components/FolderLoadingPage.tsx
@@ -1,0 +1,15 @@
+import { FolderContentHeader } from './FolderContentHeader/FolderContentHeader';
+import { FolderContentLayout } from './FolderContentLayout';
+import { PickContentLayout } from './PickContentLayout';
+import { PickRecordHeader } from './PickRecord';
+
+export function FolderLoadingPage() {
+  return (
+    <FolderContentLayout>
+      <FolderContentHeader />
+      <PickContentLayout>
+        <PickRecordHeader />
+      </PickContentLayout>
+    </FolderContentLayout>
+  );
+}

--- a/frontend/techpick/src/components/FolderTree/HorizontalResizableContainer.tsx
+++ b/frontend/techpick/src/components/FolderTree/HorizontalResizableContainer.tsx
@@ -1,27 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 import { Resizable } from 're-resizable';
 import { horizontalResizingContainerLayout } from '@/components/FolderTree/tree.css';
 export function HorizontalResizableContainer({ children }: PropsWithChildren) {
-  const [minWidth, setMinWidth] = useState('192px');
+  const minWidth = '256px';
   const MAX_WIDTH = '600px';
-
-  const updateMinWidth = () => {
-    const curWidth = window.innerWidth < 1440 ? '192px' : '256px';
-    setMinWidth(curWidth);
-  };
-
-  useEffect(function onHorizontalResizableContainerLoad() {
-    updateMinWidth();
-
-    window.addEventListener('resize', updateMinWidth);
-
-    return () => {
-      window.removeEventListener('resize', updateMinWidth);
-    };
-  }, []);
 
   return (
     <Resizable

--- a/frontend/techpick/src/hooks/index.ts
+++ b/frontend/techpick/src/hooks/index.ts
@@ -8,3 +8,4 @@ export { useResetPickFocusOnOutsideClick } from './useResetPickFocusOnOutsideCli
 export { useClearSelectedPickIdsOnMount } from './useClearSelectedPickIdsOnMount';
 export { useFetchTagList } from './useFetchTagList';
 export { useGetDragOverStyle } from './useGetDragOverStyle';
+export { useFetchPickRecordByFolderId } from './useFetchPickRecordByFolderId';

--- a/frontend/techpick/src/hooks/useClearSelectedPickIdsOnMount.ts
+++ b/frontend/techpick/src/hooks/useClearSelectedPickIdsOnMount.ts
@@ -6,7 +6,10 @@ import { usePickStore } from '@/stores';
 export function useClearSelectedPickIdsOnMount() {
   const { setSelectedPickIdList } = usePickStore();
 
-  useEffect(function clearSelectedPickIdsOnMount() {
-    setSelectedPickIdList([]);
-  }, []);
+  useEffect(
+    function clearSelectedPickIdsOnMount() {
+      setSelectedPickIdList([]);
+    },
+    [setSelectedPickIdList]
+  );
 }

--- a/frontend/techpick/src/hooks/useFetchPickRecordByFolderId.ts
+++ b/frontend/techpick/src/hooks/useFetchPickRecordByFolderId.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useCallback, useRef } from 'react';
+import { usePickStore } from '@/stores';
+import { FetchRequestType } from '@/types/FetchRequestType';
+import type { PickRecordValueType } from '@/types';
+
+export function useFetchPickRecordByFolderId({
+  folderId,
+  alwaysFetch = false,
+}: useFetchPickInfoParams): useFetchResult {
+  const fetchPickDataByFolderId = usePickStore(
+    (state) => state.fetchPickDataByFolderId
+  );
+  const pickRecord = usePickStore((state) => state.pickRecord);
+  const isFetchedRef = useRef(false);
+
+  const queryFunction = useCallback(
+    async (folderId: number) => {
+      await fetchPickDataByFolderId(folderId);
+    },
+    [fetchPickDataByFolderId]
+  );
+
+  useEffect(() => {
+    if (!(typeof folderId === 'number')) {
+      return;
+    }
+
+    if (!pickRecord[folderId] || (alwaysFetch && !isFetchedRef.current)) {
+      isFetchedRef.current = true;
+      queryFunction(folderId);
+    }
+  }, [queryFunction, folderId, pickRecord]);
+
+  if (typeof folderId !== 'number') {
+    return {
+      isLoading: false,
+      isError: true,
+      error: 'folderId is not number',
+      data: null,
+      refetch: async () => {},
+    };
+  }
+
+  const { isLoading, isError, data, error } = pickRecord[folderId] ?? {
+    isLoading: false,
+    isError: false,
+    data: null,
+    error: null,
+  };
+  return {
+    isLoading,
+    isError,
+    error,
+    data,
+    refetch: async () => {
+      queryFunction(folderId);
+    },
+  };
+}
+
+interface useFetchPickInfoParams {
+  folderId: number | undefined | null;
+  alwaysFetch?: boolean;
+}
+
+interface useFetchResult extends FetchRequestType<PickRecordValueType> {
+  refetch: () => Promise<void>;
+}

--- a/frontend/techpick/src/stores/pickStore/pickStore.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.ts
@@ -10,73 +10,18 @@ import {
 } from '@/apis/pick';
 import { getPickListByQueryParam } from '@/apis/pick/getPicks';
 import { isPickDraggableObject, reorderSortableIdList } from '@/utils';
-import type { Active, Over } from '@dnd-kit/core';
 import type {
-  PickRecordType,
+  DeleteSelectedPicksPayload,
+  PickAction,
+  PickState,
+} from './pickStore.type';
+import type {
   PickInfoType,
   PickRecordValueType,
-  SelectedPickIdListType,
-  PickDraggableObjectType,
-  PickToFolderDroppableObjectType,
   SearchPicksResponseType,
-  UpdatePickRequestType,
 } from '@/types';
 
 enableMapSet();
-
-type PickState = {
-  searchResult: SearchPicksResponseType;
-  pickRecord: PickRecordType;
-  focusPickId: number | null;
-  selectedPickIdList: SelectedPickIdListType;
-  isDragging: boolean;
-  draggingPickInfo: PickInfoType | null | undefined;
-};
-
-type PickAction = {
-  fetchPickDataByFolderId: (folderId: number) => Promise<void>;
-  getOrderedPickIdListByFolderId: (folderId: number) => number[];
-  getOrderedPickListByFolderId: (folderId: number) => PickInfoType[];
-  getPickInfoByFolderIdAndPickId: (
-    folderId: number,
-    pickId: number
-  ) => PickInfoType | null | undefined;
-  hasPickRecordValue: (
-    pickRecordValue: PickRecordValueType | undefined
-  ) => pickRecordValue is PickRecordValueType;
-  movePicksToEqualFolder: (movePickPayload: MovePickPayload) => Promise<void>;
-  movePicksToDifferentFolder: (
-    movePickPayload: movePicksToDifferentFolder
-  ) => Promise<void>;
-  moveSelectedPicksToRecycleBinFolder: (
-    payload: MoveSelectedPicksToRecycleBinFolderPayload
-  ) => Promise<void>;
-  deleteSelectedPicks: (
-    deleteSelectedPicksPayload: DeleteSelectedPicksPayload
-  ) => Promise<void>;
-  setSelectedPickIdList: (
-    newSelectedPickIdList: SelectedPickIdListType
-  ) => void;
-  selectSinglePick: (pickId: number) => void;
-  setIsDragging: (isDragging: boolean) => void;
-  setFocusedPickId: (focusedPickId: number) => void;
-  setDraggingPickInfo: (
-    draggingPickInfo: PickInfoType | null | undefined
-  ) => void;
-  /**
-   * queryParam을 통으로 검색에 사용합니다. (search 패널)
-   */
-  searchPicksByQueryParam: (
-    param: string,
-    cursor?: number | string,
-    size?: number
-  ) => Promise<void>;
-  getSearchResult: () => SearchPicksResponseType;
-  updatePickInfo: (
-    pickParentFolderId: number,
-    pickInfo: UpdatePickRequestType
-  ) => Promise<void>;
-};
 
 const initialState: PickState = {
   searchResult: { lastCursor: 0, hasNext: true } as SearchPicksResponseType,
@@ -92,6 +37,12 @@ export const usePickStore = create<PickState & PickAction>()(
     immer((set, get) => ({
       ...initialState,
       fetchPickDataByFolderId: async (folderId) => {
+        // pickRecord[folderId]
+
+        // isLoading true
+
+        // isError
+
         try {
           const { pickInfoRecord, pickIdOrderedList } =
             await getPicksByFolderId(folderId);
@@ -102,8 +53,8 @@ export const usePickStore = create<PickState & PickAction>()(
               pickInfoRecord,
             };
           });
-        } catch (error) {
-          console.log('fetchPickDataByFolderId error', error);
+        } catch {
+          /* empty */
         }
       },
       getOrderedPickIdListByFolderId: (folderId) => {
@@ -595,23 +546,3 @@ export const usePickStore = create<PickState & PickAction>()(
     }))
   )
 );
-
-type MovePickPayload = {
-  folderId: number;
-  from: Active;
-  to: Over;
-};
-
-type movePicksToDifferentFolder = {
-  from: PickDraggableObjectType;
-  to: PickToFolderDroppableObjectType;
-};
-
-type MoveSelectedPicksToRecycleBinFolderPayload = {
-  picksParentFolderId: number;
-  recycleBinFolderId: number;
-};
-
-type DeleteSelectedPicksPayload = {
-  recycleBinFolderId: number;
-};

--- a/frontend/techpick/src/stores/pickStore/pickStore.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.ts
@@ -87,29 +87,7 @@ export const usePickStore = create<PickState & PickAction>()(
 
         return pickIdOrderedList;
       },
-      getOrderedPickListByFolderId: (folderId: number) => {
-        const pickRecordValue = get().pickRecord[`${folderId}`];
 
-        if (
-          !get().hasPickRecordValue(pickRecordValue?.data) ||
-          !pickRecordValue.data
-        ) {
-          return [];
-        }
-
-        const { pickIdOrderedList, pickInfoRecord } = pickRecordValue.data;
-        const pickOrderedList: PickInfoType[] = [];
-
-        for (const pickId of pickIdOrderedList) {
-          const pickInfo = pickInfoRecord[`${pickId}`];
-
-          if (pickInfo) {
-            pickOrderedList.push(pickInfo);
-          }
-        }
-
-        return pickOrderedList;
-      },
       getPickInfoByFolderIdAndPickId: (folderId, pickId) => {
         const pickRecordValue = get().pickRecord[`${folderId}`];
 

--- a/frontend/techpick/src/stores/pickStore/pickStore.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.ts
@@ -37,11 +37,18 @@ export const usePickStore = create<PickState & PickAction>()(
     immer((set, get) => ({
       ...initialState,
       fetchPickDataByFolderId: async (folderId) => {
-        // pickRecord[folderId]
+        set((state) => {
+          if (!state.pickRecord[folderId]) {
+            state.pickRecord[folderId] = {
+              data: null,
+              isError: false,
+              isLoading: false,
+              error: 'null',
+            };
+          }
 
-        // isLoading true
-
-        // isError
+          state.pickRecord[folderId].isLoading = true;
+        });
 
         try {
           const { pickInfoRecord, pickIdOrderedList } =
@@ -49,32 +56,48 @@ export const usePickStore = create<PickState & PickAction>()(
 
           set((state) => {
             state.pickRecord[folderId] = {
-              pickIdOrderedList,
-              pickInfoRecord,
+              isLoading: false,
+              isError: false,
+              error: null,
+              data: { pickIdOrderedList, pickInfoRecord },
             };
           });
         } catch {
-          /* empty */
+          set((state) => {
+            state.pickRecord[folderId] = {
+              isLoading: false,
+              isError: true,
+              error: `fetchPickDataByFolderId ${folderId} error`,
+              data: null,
+            };
+          });
         }
       },
       getOrderedPickIdListByFolderId: (folderId) => {
         const pickRecordValue = get().pickRecord[`${folderId}`];
 
-        if (!get().hasPickRecordValue(pickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(pickRecordValue?.data) ||
+          !pickRecordValue.data
+        ) {
           return [];
         }
-        const { pickIdOrderedList } = pickRecordValue;
+
+        const { pickIdOrderedList } = pickRecordValue.data;
 
         return pickIdOrderedList;
       },
       getOrderedPickListByFolderId: (folderId: number) => {
         const pickRecordValue = get().pickRecord[`${folderId}`];
 
-        if (!get().hasPickRecordValue(pickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(pickRecordValue?.data) ||
+          !pickRecordValue.data
+        ) {
           return [];
         }
 
-        const { pickIdOrderedList, pickInfoRecord } = pickRecordValue;
+        const { pickIdOrderedList, pickInfoRecord } = pickRecordValue.data;
         const pickOrderedList: PickInfoType[] = [];
 
         for (const pickId of pickIdOrderedList) {
@@ -90,11 +113,14 @@ export const usePickStore = create<PickState & PickAction>()(
       getPickInfoByFolderIdAndPickId: (folderId, pickId) => {
         const pickRecordValue = get().pickRecord[`${folderId}`];
 
-        if (!get().hasPickRecordValue(pickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(pickRecordValue?.data) ||
+          !pickRecordValue.data
+        ) {
           return null;
         }
 
-        const { pickIdOrderedList, pickInfoRecord } = pickRecordValue;
+        const { pickIdOrderedList, pickInfoRecord } = pickRecordValue.data;
 
         if (!pickIdOrderedList.includes(pickId)) {
           return null;
@@ -124,25 +150,29 @@ export const usePickStore = create<PickState & PickAction>()(
         const folderId = fromData.sortable.containerId;
         const pickRecordValue = get().pickRecord[folderId];
 
-        if (!get().hasPickRecordValue(pickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(pickRecordValue?.data) ||
+          !pickRecordValue.data
+        ) {
           return;
         }
 
-        const prevPickIdOrderedList = pickRecordValue.pickIdOrderedList;
+        const prevPickIdOrderedList = pickRecordValue.data.pickIdOrderedList;
         const fromId = from.id;
         const toId = to.id;
 
         set((state) => {
-          if (!state.pickRecord[folderId]) {
+          if (!state.pickRecord[folderId]?.data) {
             return;
           }
 
-          state.pickRecord[folderId].pickIdOrderedList = reorderSortableIdList({
-            sortableIdList: prevPickIdOrderedList,
-            fromId,
-            toId,
-            selectedFolderList: state.selectedPickIdList,
-          });
+          state.pickRecord[folderId].data.pickIdOrderedList =
+            reorderSortableIdList({
+              sortableIdList: prevPickIdOrderedList,
+              fromId,
+              toId,
+              selectedFolderList: state.selectedPickIdList,
+            });
         });
 
         try {
@@ -155,11 +185,14 @@ export const usePickStore = create<PickState & PickAction>()(
           set((state) => {
             const curPickRecordValue = state.pickRecord[`${folderId}`];
 
-            if (!get().hasPickRecordValue(curPickRecordValue)) {
+            if (
+              !get().hasPickRecordValue(curPickRecordValue?.data) ||
+              !curPickRecordValue.data
+            ) {
               return;
             }
 
-            curPickRecordValue.pickIdOrderedList = prevPickIdOrderedList;
+            curPickRecordValue.data.pickIdOrderedList = prevPickIdOrderedList;
             state.pickRecord[`${folderId}`] = curPickRecordValue;
           });
         }
@@ -171,24 +204,32 @@ export const usePickStore = create<PickState & PickAction>()(
         const currentPickRecordValue = get().pickRecord[currentFolderId];
         let nextPickRecordValue = get().pickRecord[nextFolderId];
 
-        if (!get().hasPickRecordValue(currentPickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(currentPickRecordValue?.data) ||
+          !currentPickRecordValue.data
+        ) {
           return;
         }
 
         /**
          * @description 다음 들어갈 곳에 값이 없으면 만들어줘야한다.
          */
-        if (!get().hasPickRecordValue(nextPickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(nextPickRecordValue?.data) ||
+          !nextPickRecordValue.data
+        ) {
           set((state) => {
             state.pickRecord[nextFolderId] = {
-              pickIdOrderedList: [],
-              pickInfoRecord: {},
+              data: { pickIdOrderedList: [], pickInfoRecord: {} },
+              isLoading: false,
+              isError: false,
+              error: null,
             };
           });
           nextPickRecordValue = get().pickRecord[currentFolderId];
         }
 
-        if (!nextPickRecordValue) {
+        if (!nextPickRecordValue?.data) {
           return;
         }
 
@@ -199,7 +240,7 @@ export const usePickStore = create<PickState & PickAction>()(
         const {
           pickInfoRecord: prevCurrentPickInfoRecord,
           pickIdOrderedList: prevCurrentPickIdOrderedList,
-        } = currentPickRecordValue;
+        } = currentPickRecordValue.data;
 
         // 선택된 정보 가져오기.
         for (const selectedPickId of selectedPickIdList) {
@@ -217,21 +258,24 @@ export const usePickStore = create<PickState & PickAction>()(
         const {
           pickIdOrderedList: prevNextPickIdOrderedList,
           pickInfoRecord: prevNextPickInfoRecord,
-        } = nextPickRecordValue;
+        } = nextPickRecordValue.data;
 
         // 값 추가하기.
         set((state) => {
-          if (!get().hasPickRecordValue(state.pickRecord[nextFolderId])) {
+          if (
+            !get().hasPickRecordValue(state.pickRecord[nextFolderId]?.data) ||
+            !state.pickRecord[nextFolderId].data
+          ) {
             return;
           }
 
           for (const selectedPickInfo of selectedPickInfoList) {
-            state.pickRecord[nextFolderId].pickInfoRecord[
+            state.pickRecord[nextFolderId].data.pickInfoRecord[
               `${selectedPickInfo.id}`
             ] = selectedPickInfo;
           }
 
-          state.pickRecord[nextFolderId].pickIdOrderedList.splice(
+          state.pickRecord[nextFolderId].data.pickIdOrderedList.splice(
             0,
             0,
             ...selectedPickIdList
@@ -240,17 +284,22 @@ export const usePickStore = create<PickState & PickAction>()(
 
         // 현재 폴더에서 삭제.
         set((state) => {
-          if (!get().hasPickRecordValue(state.pickRecord[currentFolderId])) {
+          if (
+            !get().hasPickRecordValue(
+              state.pickRecord[currentFolderId]?.data
+            ) ||
+            !state.pickRecord[currentFolderId].data
+          ) {
             return;
           }
 
           for (const selectedPickInfo of selectedPickInfoList) {
-            state.pickRecord[currentFolderId].pickInfoRecord[
+            state.pickRecord[currentFolderId].data.pickInfoRecord[
               `${selectedPickInfo.id}`
             ] = undefined;
           }
 
-          state.pickRecord[currentFolderId].pickIdOrderedList =
+          state.pickRecord[currentFolderId].data.pickIdOrderedList =
             prevCurrentPickIdOrderedList.filter(
               (pickId) => !selectedPickIdList.includes(pickId)
             );
@@ -265,24 +314,24 @@ export const usePickStore = create<PickState & PickAction>()(
         } catch {
           // 현재 폴더에서 이전 상태로 원복
           set((state) => {
-            if (!state.pickRecord[currentFolderId]) {
+            if (!state.pickRecord[currentFolderId]?.data) {
               return;
             }
-            state.pickRecord[currentFolderId].pickIdOrderedList =
+            state.pickRecord[currentFolderId].data.pickIdOrderedList =
               prevCurrentPickIdOrderedList;
-            state.pickRecord[currentFolderId].pickInfoRecord =
+            state.pickRecord[currentFolderId].data.pickInfoRecord =
               prevCurrentPickInfoRecord;
           });
 
           // 이동한 폴더를 이전 상태로 원복
           set((state) => {
-            if (!state.pickRecord[nextFolderId]) {
+            if (!state.pickRecord[nextFolderId]?.data) {
               return;
             }
 
-            state.pickRecord[nextFolderId].pickIdOrderedList =
+            state.pickRecord[nextFolderId].data.pickIdOrderedList =
               prevNextPickIdOrderedList;
-            state.pickRecord[nextFolderId].pickInfoRecord =
+            state.pickRecord[nextFolderId].data.pickInfoRecord =
               prevNextPickInfoRecord;
           });
         }
@@ -295,24 +344,32 @@ export const usePickStore = create<PickState & PickAction>()(
         const currentPickRecordValue = get().pickRecord[currentFolderId];
         let nextPickRecordValue = get().pickRecord[nextFolderId];
 
-        if (!get().hasPickRecordValue(currentPickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(currentPickRecordValue?.data) ||
+          !currentPickRecordValue.data
+        ) {
           return;
         }
 
         /**
          * @description 다음 들어갈 곳에 값이 없으면 만들어줘야한다.
          */
-        if (!get().hasPickRecordValue(nextPickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(nextPickRecordValue?.data) ||
+          !nextPickRecordValue.data
+        ) {
           set((state) => {
             state.pickRecord[nextFolderId] = {
-              pickIdOrderedList: [],
-              pickInfoRecord: {},
+              isLoading: false,
+              isError: false,
+              error: null,
+              data: { pickIdOrderedList: [], pickInfoRecord: {} },
             };
           });
           nextPickRecordValue = get().pickRecord[currentFolderId];
         }
 
-        if (!nextPickRecordValue) {
+        if (!nextPickRecordValue?.data) {
           return;
         }
 
@@ -323,7 +380,7 @@ export const usePickStore = create<PickState & PickAction>()(
         const {
           pickInfoRecord: prevCurrentPickInfoRecord,
           pickIdOrderedList: prevCurrentPickIdOrderedList,
-        } = currentPickRecordValue;
+        } = currentPickRecordValue.data;
 
         // 선택된 정보 가져오기.
         for (const selectedPickId of selectedPickIdList) {
@@ -341,21 +398,24 @@ export const usePickStore = create<PickState & PickAction>()(
         const {
           pickIdOrderedList: prevNextPickIdOrderedList,
           pickInfoRecord: prevNextPickInfoRecord,
-        } = nextPickRecordValue;
+        } = nextPickRecordValue.data;
 
         // 값 추가하기.
         set((state) => {
-          if (!get().hasPickRecordValue(state.pickRecord[nextFolderId])) {
+          if (
+            !get().hasPickRecordValue(state.pickRecord[nextFolderId]?.data) ||
+            !state.pickRecord[nextFolderId].data
+          ) {
             return;
           }
 
           for (const selectedPickInfo of selectedPickInfoList) {
-            state.pickRecord[nextFolderId].pickInfoRecord[
+            state.pickRecord[nextFolderId].data.pickInfoRecord[
               `${selectedPickInfo.id}`
             ] = selectedPickInfo;
           }
 
-          state.pickRecord[nextFolderId].pickIdOrderedList.splice(
+          state.pickRecord[nextFolderId].data.pickIdOrderedList.splice(
             0,
             0,
             ...selectedPickIdList
@@ -364,17 +424,22 @@ export const usePickStore = create<PickState & PickAction>()(
 
         // 현재 폴더에서 삭제.
         set((state) => {
-          if (!get().hasPickRecordValue(state.pickRecord[currentFolderId])) {
+          if (
+            !get().hasPickRecordValue(
+              state.pickRecord[currentFolderId]?.data
+            ) ||
+            !state.pickRecord[currentFolderId].data
+          ) {
             return;
           }
 
           for (const selectedPickInfo of selectedPickInfoList) {
-            state.pickRecord[currentFolderId].pickInfoRecord[
+            state.pickRecord[currentFolderId].data.pickInfoRecord[
               `${selectedPickInfo.id}`
             ] = undefined;
           }
 
-          state.pickRecord[currentFolderId].pickIdOrderedList =
+          state.pickRecord[currentFolderId].data.pickIdOrderedList =
             prevCurrentPickIdOrderedList.filter(
               (pickId) => !selectedPickIdList.includes(pickId)
             );
@@ -388,24 +453,24 @@ export const usePickStore = create<PickState & PickAction>()(
         } catch {
           // 현재 폴더에서 이전 상태로 원복
           set((state) => {
-            if (!state.pickRecord[currentFolderId]) {
+            if (!state.pickRecord[currentFolderId]?.data) {
               return;
             }
-            state.pickRecord[currentFolderId].pickIdOrderedList =
+            state.pickRecord[currentFolderId].data.pickIdOrderedList =
               prevCurrentPickIdOrderedList;
-            state.pickRecord[currentFolderId].pickInfoRecord =
+            state.pickRecord[currentFolderId].data.pickInfoRecord =
               prevCurrentPickInfoRecord;
           });
 
           // 이동한 폴더를 이전 상태로 원복
           set((state) => {
-            if (!state.pickRecord[nextFolderId]) {
+            if (!state.pickRecord[nextFolderId]?.data) {
               return;
             }
 
-            state.pickRecord[nextFolderId].pickIdOrderedList =
+            state.pickRecord[nextFolderId].data.pickIdOrderedList =
               prevNextPickIdOrderedList;
-            state.pickRecord[nextFolderId].pickInfoRecord =
+            state.pickRecord[nextFolderId].data.pickInfoRecord =
               prevNextPickInfoRecord;
           });
         }
@@ -416,7 +481,10 @@ export const usePickStore = create<PickState & PickAction>()(
         const recycleBinFolderPickRecord = get().pickRecord[recycleBinFolderId];
         const selectedPickIdList = get().selectedPickIdList;
 
-        if (!get().hasPickRecordValue(recycleBinFolderPickRecord)) {
+        if (
+          !get().hasPickRecordValue(recycleBinFolderPickRecord?.data) ||
+          recycleBinFolderPickRecord.data
+        ) {
           return;
         }
 
@@ -424,17 +492,23 @@ export const usePickStore = create<PickState & PickAction>()(
 
         // 미리 삭제.
         set((state) => {
-          if (!get().hasPickRecordValue(state.pickRecord[recycleBinFolderId])) {
+          if (
+            !get().hasPickRecordValue(
+              state.pickRecord[recycleBinFolderId]?.data
+            ) ||
+            !state.pickRecord[recycleBinFolderId].data
+          ) {
             return;
           }
 
           for (const selectedId of selectedPickIdList) {
-            state.pickRecord[recycleBinFolderId].pickInfoRecord[selectedId] =
-              undefined;
+            state.pickRecord[recycleBinFolderId].data.pickInfoRecord[
+              selectedId
+            ] = undefined;
           }
 
-          state.pickRecord[recycleBinFolderId].pickIdOrderedList =
-            state.pickRecord[recycleBinFolderId].pickIdOrderedList.filter(
+          state.pickRecord[recycleBinFolderId].data.pickIdOrderedList =
+            state.pickRecord[recycleBinFolderId].data.pickIdOrderedList.filter(
               (pickId) => !selectedPickIdList.includes(pickId)
             );
         });
@@ -469,13 +543,11 @@ export const usePickStore = create<PickState & PickAction>()(
           state.focusPickId = focusedPickId;
         });
       },
-
       setDraggingPickInfo: (draggingPickInfo) => {
         set((state) => {
           state.draggingPickInfo = draggingPickInfo;
         });
       },
-
       searchPicksByQueryParam: async (
         param: string,
         cursor?: number | string,
@@ -502,11 +574,14 @@ export const usePickStore = create<PickState & PickAction>()(
 
         const pickRecordValue = get().pickRecord[pickParentFolderId];
 
-        if (!get().hasPickRecordValue(pickRecordValue)) {
+        if (
+          !get().hasPickRecordValue(pickRecordValue?.data) ||
+          !pickRecordValue.data
+        ) {
           return;
         }
 
-        const { pickInfoRecord } = pickRecordValue;
+        const { pickInfoRecord } = pickRecordValue.data;
 
         if (!pickInfoRecord[pickId]) {
           return;
@@ -521,11 +596,11 @@ export const usePickStore = create<PickState & PickAction>()(
 
         // 미리 업데이트
         set((state) => {
-          if (!state.pickRecord[pickParentFolderId]) {
+          if (!state.pickRecord[pickParentFolderId]?.data) {
             return;
           }
 
-          const { pickInfoRecord } = state.pickRecord[pickParentFolderId];
+          const { pickInfoRecord } = state.pickRecord[pickParentFolderId].data;
           pickInfoRecord[pickId] = newPickInfo;
         });
 
@@ -534,11 +609,12 @@ export const usePickStore = create<PickState & PickAction>()(
         } catch {
           // 실패하면 원복하기.
           set((state) => {
-            if (!state.pickRecord[pickParentFolderId]) {
+            if (!state.pickRecord[pickParentFolderId]?.data) {
               return;
             }
 
-            const { pickInfoRecord } = state.pickRecord[pickParentFolderId];
+            const { pickInfoRecord } =
+              state.pickRecord[pickParentFolderId].data;
             pickInfoRecord[pickId] = prevPickInfo;
           });
         }

--- a/frontend/techpick/src/stores/pickStore/pickStore.type.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.type.ts
@@ -28,7 +28,7 @@ export type PickAction = {
     pickId: number
   ) => PickInfoType | null | undefined;
   hasPickRecordValue: (
-    pickRecordValue: PickRecordValueType | undefined
+    pickRecordValue: PickRecordValueType | undefined | null
   ) => pickRecordValue is PickRecordValueType;
   movePicksToEqualFolder: (movePickPayload: MovePickPayload) => Promise<void>;
   movePicksToDifferentFolder: (
@@ -49,6 +49,7 @@ export type PickAction = {
   setDraggingPickInfo: (
     draggingPickInfo: PickInfoType | null | undefined
   ) => void;
+
   /**
    * queryParam을 통으로 검색에 사용합니다. (search 패널)
    */

--- a/frontend/techpick/src/stores/pickStore/pickStore.type.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.type.ts
@@ -1,0 +1,85 @@
+import type { Active, Over } from '@dnd-kit/core';
+import type {
+  PickDraggableObjectType,
+  PickInfoType,
+  PickRecordType,
+  PickRecordValueType,
+  PickToFolderDroppableObjectType,
+  SearchPicksResponseType,
+  SelectedPickIdListType,
+  UpdatePickRequestType,
+} from '@/types';
+
+export type PickState = {
+  searchResult: SearchPicksResponseType;
+  pickRecord: PickRecordType;
+  focusPickId: number | null;
+  selectedPickIdList: SelectedPickIdListType;
+  isDragging: boolean;
+  draggingPickInfo: PickInfoType | null | undefined;
+};
+
+export type PickAction = {
+  fetchPickDataByFolderId: (folderId: number) => Promise<void>;
+  getOrderedPickIdListByFolderId: (folderId: number) => number[];
+  getOrderedPickListByFolderId: (folderId: number) => PickInfoType[];
+  getPickInfoByFolderIdAndPickId: (
+    folderId: number,
+    pickId: number
+  ) => PickInfoType | null | undefined;
+  hasPickRecordValue: (
+    pickRecordValue: PickRecordValueType | undefined
+  ) => pickRecordValue is PickRecordValueType;
+  movePicksToEqualFolder: (movePickPayload: MovePickPayload) => Promise<void>;
+  movePicksToDifferentFolder: (
+    movePickPayload: movePicksToDifferentFolder
+  ) => Promise<void>;
+  moveSelectedPicksToRecycleBinFolder: (
+    payload: MoveSelectedPicksToRecycleBinFolderPayload
+  ) => Promise<void>;
+  deleteSelectedPicks: (
+    deleteSelectedPicksPayload: DeleteSelectedPicksPayload
+  ) => Promise<void>;
+  setSelectedPickIdList: (
+    newSelectedPickIdList: SelectedPickIdListType
+  ) => void;
+  selectSinglePick: (pickId: number) => void;
+  setIsDragging: (isDragging: boolean) => void;
+  setFocusedPickId: (focusedPickId: number) => void;
+  setDraggingPickInfo: (
+    draggingPickInfo: PickInfoType | null | undefined
+  ) => void;
+  /**
+   * queryParam을 통으로 검색에 사용합니다. (search 패널)
+   */
+  searchPicksByQueryParam: (
+    param: string,
+    cursor?: number | string,
+    size?: number
+  ) => Promise<void>;
+  getSearchResult: () => SearchPicksResponseType;
+  updatePickInfo: (
+    pickParentFolderId: number,
+    pickInfo: UpdatePickRequestType
+  ) => Promise<void>;
+};
+
+export type MovePickPayload = {
+  folderId: number;
+  from: Active;
+  to: Over;
+};
+
+export type movePicksToDifferentFolder = {
+  from: PickDraggableObjectType;
+  to: PickToFolderDroppableObjectType;
+};
+
+export type MoveSelectedPicksToRecycleBinFolderPayload = {
+  picksParentFolderId: number;
+  recycleBinFolderId: number;
+};
+
+export type DeleteSelectedPicksPayload = {
+  recycleBinFolderId: number;
+};

--- a/frontend/techpick/src/stores/pickStore/pickStore.type.ts
+++ b/frontend/techpick/src/stores/pickStore/pickStore.type.ts
@@ -22,7 +22,6 @@ export type PickState = {
 export type PickAction = {
   fetchPickDataByFolderId: (folderId: number) => Promise<void>;
   getOrderedPickIdListByFolderId: (folderId: number) => number[];
-  getOrderedPickListByFolderId: (folderId: number) => PickInfoType[];
   getPickInfoByFolderIdAndPickId: (
     folderId: number,
     pickId: number

--- a/frontend/techpick/src/types/FetchRequestType.ts
+++ b/frontend/techpick/src/types/FetchRequestType.ts
@@ -1,0 +1,9 @@
+/**
+ * @description zustand에서 api 호출 시에 확인할 수 있는 타입입니다.
+ */
+export interface FetchRequestType<T> {
+  isLoading: boolean;
+  data: T | null;
+  isError: boolean;
+  error: string | null;
+}

--- a/frontend/techpick/src/types/pick.type.ts
+++ b/frontend/techpick/src/types/pick.type.ts
@@ -1,3 +1,4 @@
+import type { FetchRequestType } from './FetchRequestType';
 import type { Concrete } from './util.type';
 import type { components } from '@/schema';
 
@@ -6,10 +7,15 @@ export type PickInfoType = Concrete<
 >;
 
 export type PickInfoRecordType = {
-  [pickId: string]: PickInfoType | undefined;
+  [pickId: string]: PickInfoType | null | undefined;
 };
 
 export type PickIdOrderedListType = number[];
+
+export type PickSelectionResult = {
+  pickIdOrderedList: PickIdOrderedListType;
+  pickInfoRecord: PickInfoRecordType;
+};
 
 export type PickRecordValueType = {
   pickIdOrderedList: PickIdOrderedListType;
@@ -17,7 +23,7 @@ export type PickRecordValueType = {
 };
 
 export type PickRecordType = {
-  [folderId: string]: PickRecordValueType | undefined;
+  [folderId: string]: FetchRequestType<PickRecordValueType> | undefined;
 };
 
 export type PickListType = PickInfoType[];

--- a/frontend/techpick/src/utils/getOrderedPickListByFolderId.ts
+++ b/frontend/techpick/src/utils/getOrderedPickListByFolderId.ts
@@ -1,0 +1,23 @@
+import type { PickInfoType, PickRecordValueType } from '@/types';
+
+export const getOrderedPickListByFolderId = (
+  pickRecordValue: PickRecordValueType | null | undefined
+) => {
+  if (!pickRecordValue) {
+    return [];
+  }
+
+  const { pickIdOrderedList, pickInfoRecord } = pickRecordValue;
+
+  const pickOrderedList: PickInfoType[] = [];
+
+  for (const pickId of pickIdOrderedList) {
+    const pickInfo = pickInfoRecord[`${pickId}`];
+
+    if (pickInfo) {
+      pickOrderedList.push(pickInfo);
+    }
+  }
+
+  return pickOrderedList;
+};

--- a/frontend/techpick/src/utils/index.ts
+++ b/frontend/techpick/src/utils/index.ts
@@ -14,3 +14,4 @@ export { isShallowEqualValue } from './isShallowEqualValue';
 export { getSelectedPickRange } from './getSelectedPickRange';
 export { numberToRandomColor } from './numberToRandomColor';
 export { getFolderLinkByType } from './getFolderLinkByType';
+export { getOrderedPickListByFolderId } from './getOrderedPickListByFolderId';


### PR DESCRIPTION
- Close #613 

## What is this PR? 🔍

- 기능 :
- issue : #613 

## Changes 📝
- 로딩상태와 값이 비어있을 때의 상태를 구분할 수 있습니다. 
- 현재 folderId를 이용해 pick을 받아오는 걸 중앙 스토어에서 직접 호출하지 않고 hook을 이용해서 호출합니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
