### PR TITLE
[FIX] 폴더 콘텍스트 및 다이얼로그 수정 및 공통 hook 생성

### DIFF
--- a/frontend/techpick/src/components/FolderTree/FolderContextMenu.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderContextMenu.tsx
@@ -2,7 +2,6 @@
 
 import type { PropsWithChildren } from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
-import * as Dialog from '@radix-ui/react-dialog';
 import { FolderPen, FolderX, ScreenShare } from 'lucide-react';
 import { getPortalContainer } from '@/utils';
 import {
@@ -14,6 +13,7 @@ export function FolderContextMenu({
   showRenameInput,
   shareFolder,
   onShow = () => {},
+  onClickRemoveFolder,
   children,
 }: PropsWithChildren<FolderContextMenuProps>) {
   const portalContainer = getPortalContainer();
@@ -38,12 +38,14 @@ export function FolderContextMenu({
             <FolderPen />
             <p>폴더명 변경</p>
           </ContextMenu.Item>
-          <Dialog.Trigger asChild>
-            <ContextMenu.Item className={contextMenuItemStyle}>
-              <FolderX />
-              <p>휴지통으로 이동</p>
-            </ContextMenu.Item>
-          </Dialog.Trigger>
+
+          <ContextMenu.Item
+            className={contextMenuItemStyle}
+            onSelect={onClickRemoveFolder}
+          >
+            <FolderX />
+            <p>휴지통으로 이동</p>
+          </ContextMenu.Item>
           <ContextMenu.Item
             className={contextMenuItemStyle}
             onSelect={shareFolder}
@@ -61,4 +63,5 @@ interface FolderContextMenuProps {
   showRenameInput: () => void;
   shareFolder: () => void;
   onShow?: () => void;
+  onClickRemoveFolder: () => void;
 }

--- a/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import type { MouseEvent } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 import { FolderClosedIcon, FolderOpenIcon } from 'lucide-react';
 import { shareFolder } from '@/apis/folder/shareFolder';
 import { ROUTES } from '@/constants';
@@ -35,6 +34,8 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
   const [isUpdate, setIsUpdate] = useState(false);
   const isSelected = selectedFolderList.includes(id);
   const isHover = id === hoverFolderId;
+  const [isRemoveFolderDialogOpen, setIsRemoveFolderDialogOpen] =
+    useState(false);
 
   const handleShiftSelect = (id: number, treeDataMap: FolderMapType) => {
     if (!focusFolderId || !isSameParentFolder(id, focusFolderId, treeDataMap)) {
@@ -82,7 +83,7 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
   }
 
   return (
-    <Dialog.Root>
+    <>
       <FolderContextMenu
         showRenameInput={() => {
           setIsUpdate(true);
@@ -90,6 +91,9 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
         shareFolder={handleShareFolder}
         onShow={() => {
           selectSingleFolder(id);
+        }}
+        onClickRemoveFolder={() => {
+          setIsRemoveFolderDialogOpen(true);
         }}
       >
         <FolderLinkItem
@@ -104,8 +108,12 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
       {isDialogOpen && (
         <ShareFolderDialog onClose={handleDialogClose} uuid={uuid} />
       )}
-      <MoveFolderToRecycleBinDialog deleteFolderId={id} />
-    </Dialog.Root>
+      <MoveFolderToRecycleBinDialog
+        deleteFolderId={id}
+        isOpen={isRemoveFolderDialogOpen}
+        onOpenChange={setIsRemoveFolderDialogOpen}
+      />
+    </>
   );
 };
 

--- a/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
@@ -9,6 +9,7 @@ import { useShareDialogOpen } from '@/hooks/useShareDialogOpen';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
 import { isSelectionActive } from '@/utils';
 import { FolderContextMenu } from './FolderContextMenu';
+import { FolderDraggable } from './FolderDraggable';
 import { FolderInput } from './FolderInput';
 import { FolderLinkItem } from './FolderLinkItem';
 import {
@@ -96,14 +97,16 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
           setIsRemoveFolderDialogOpen(true);
         }}
       >
-        <FolderLinkItem
-          href={ROUTES.FOLDER_DETAIL(id)}
-          isSelected={isSelected}
-          isHovered={isHover}
-          icon={isSelected ? FolderOpenIcon : FolderClosedIcon}
-          name={name}
-          onClick={(event) => handleClick(id, event)}
-        />
+        <FolderDraggable id={id}>
+          <FolderLinkItem
+            href={ROUTES.FOLDER_DETAIL(id)}
+            isSelected={isSelected}
+            isHovered={isHover}
+            icon={isSelected ? FolderOpenIcon : FolderClosedIcon}
+            name={name}
+            onClick={(event) => handleClick(id, event)}
+          />
+        </FolderDraggable>
       </FolderContextMenu>
       {isDialogOpen && (
         <ShareFolderDialog onClose={handleDialogClose} uuid={uuid} />

--- a/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
+++ b/frontend/techpick/src/components/FolderTree/FolderListItem.tsx
@@ -5,6 +5,7 @@ import type { MouseEvent } from 'react';
 import { FolderClosedIcon, FolderOpenIcon } from 'lucide-react';
 import { shareFolder } from '@/apis/folder/shareFolder';
 import { ROUTES } from '@/constants';
+import { useDisclosure } from '@/hooks';
 import { useShareDialogOpen } from '@/hooks/useShareDialogOpen';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
 import { isSelectionActive } from '@/utils';
@@ -35,8 +36,11 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
   const [isUpdate, setIsUpdate] = useState(false);
   const isSelected = selectedFolderList.includes(id);
   const isHover = id === hoverFolderId;
-  const [isRemoveFolderDialogOpen, setIsRemoveFolderDialogOpen] =
-    useState(false);
+  const {
+    isOpen: isOpenRemoveDialog,
+    onOpen: onOpenRemoveDialog,
+    onClose: onCloseRemoveDialog,
+  } = useDisclosure();
 
   const handleShiftSelect = (id: number, treeDataMap: FolderMapType) => {
     if (!focusFolderId || !isSameParentFolder(id, focusFolderId, treeDataMap)) {
@@ -93,9 +97,7 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
         onShow={() => {
           selectSingleFolder(id);
         }}
-        onClickRemoveFolder={() => {
-          setIsRemoveFolderDialogOpen(true);
-        }}
+        onClickRemoveFolder={onOpenRemoveDialog}
       >
         <FolderDraggable id={id}>
           <FolderLinkItem
@@ -113,8 +115,8 @@ export const FolderListItem = ({ id, name }: FolderInfoItemProps) => {
       )}
       <MoveFolderToRecycleBinDialog
         deleteFolderId={id}
-        isOpen={isRemoveFolderDialogOpen}
-        onOpenChange={setIsRemoveFolderDialogOpen}
+        isOpen={isOpenRemoveDialog}
+        onOpenChange={onCloseRemoveDialog}
       />
     </>
   );

--- a/frontend/techpick/src/components/FolderTree/MoveFolderToRecycleBinDialog.tsx
+++ b/frontend/techpick/src/components/FolderTree/MoveFolderToRecycleBinDialog.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import {
-  Portal,
-  Overlay,
-  Content,
-  Title,
-  Description,
-  Close,
-} from '@radix-ui/react-dialog';
+import * as Dialog from '@radix-ui/react-dialog';
 import { XIcon } from 'lucide-react';
 import { ROUTES } from '@/constants';
 import { useTreeStore } from '@/stores';
@@ -24,6 +17,8 @@ import {
 
 export function MoveFolderToRecycleBinDialog({
   deleteFolderId,
+  isOpen,
+  onOpenChange,
 }: MoveFolderToRecycleBinDialogProps) {
   const router = useRouter();
   const { folderId: urlFolderId } = useParams<{ folderId: string }>();
@@ -40,44 +35,50 @@ export function MoveFolderToRecycleBinDialog({
   };
 
   return (
-    <Portal>
-      <Overlay className={moveRecycleBinOverlayStyle} />
-      <Content className={moveRecycleDialogContent}>
-        <div>
-          <Title className={moveRecycleBinDialogTitleStyle}>
-            폴더를 휴지통으로 이동하시겠습니다?
-          </Title>
+    <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={moveRecycleBinOverlayStyle} />
+        <Dialog.Content className={moveRecycleDialogContent}>
+          <div>
+            <Dialog.Title className={moveRecycleBinDialogTitleStyle}>
+              폴더를 휴지통으로 이동하시겠습니다?
+            </Dialog.Title>
 
-          <Description className={moveRecycleBinDialogDescriptionStyle}>
-            픽은 남지만 폴더는 사라집니다.
-          </Description>
-        </div>
-
-        <Close asChild>
-          <button className={moveRecycleBinDialogCloseButton}>
-            <XIcon size={12} />
-          </button>
-        </Close>
-
-        <div>
-          <Close asChild>
-            <button
-              className={moveRecycleBinConfirmButtonStyle}
-              onClick={moveRecycleBinAndRedirect}
+            <Dialog.Description
+              className={moveRecycleBinDialogDescriptionStyle}
             >
-              이 폴더를 삭제합니다.
-            </button>
-          </Close>
+              픽은 남지만 폴더는 사라집니다.
+            </Dialog.Description>
+          </div>
 
-          <Close asChild>
-            <button className={moveRecycleBinCancelButtonStyle}>취소</button>
-          </Close>
-        </div>
-      </Content>
-    </Portal>
+          <Dialog.Close asChild>
+            <button className={moveRecycleBinDialogCloseButton}>
+              <XIcon size={12} />
+            </button>
+          </Dialog.Close>
+
+          <div>
+            <Dialog.Close asChild>
+              <button
+                className={moveRecycleBinConfirmButtonStyle}
+                onClick={moveRecycleBinAndRedirect}
+              >
+                이 폴더를 삭제합니다.
+              </button>
+            </Dialog.Close>
+
+            <Dialog.Close asChild>
+              <button className={moveRecycleBinCancelButtonStyle}>취소</button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 
 interface MoveFolderToRecycleBinDialogProps {
   deleteFolderId: number;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }

--- a/frontend/techpick/src/components/FolderTree/TreeNode.tsx
+++ b/frontend/techpick/src/components/FolderTree/TreeNode.tsx
@@ -3,7 +3,6 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { FolderDraggable } from '@/components/FolderTree/FolderDraggable';
 import { useCreateFolderInputStore } from '@/stores/createFolderInputStore';
 import { useTreeStore } from '@/stores/dndTreeStore/dndTreeStore';
 import { FolderInput } from './FolderInput';
@@ -64,9 +63,11 @@ export function TreeNode({ id }: TreeNodeProps) {
       >
         {curTreeNodeChildList.map((treeData) => {
           return (
-            <FolderDraggable id={treeData.id} key={treeData.id}>
-              <FolderListItem id={treeData.id} name={treeData.name} />
-            </FolderDraggable>
+            <FolderListItem
+              id={treeData.id}
+              name={treeData.name}
+              key={treeData.id}
+            />
           );
         })}
       </SortableContext>

--- a/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
+++ b/frontend/techpick/src/components/FolderTree/moveFolderToRecycleBinDialog.css.ts
@@ -1,5 +1,16 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { colorVars } from 'techpick-shared';
+
+const contentShow = keyframes({
+  from: {
+    opacity: '0',
+    transform: 'translate(-50%, -48%) scale(0.96)',
+  },
+  to: {
+    opacity: '1',
+    transform: 'translate(-50%, -50%) scale(1)',
+  },
+});
 
 export const moveRecycleBinOverlayStyle = style({
   position: 'fixed',
@@ -26,7 +37,7 @@ export const moveRecycleDialogContent = style({
   `,
   padding: '16px',
   backgroundColor: colorVars.gold4,
-  animation: 'contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+  animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
 });
 
 export const moveRecycleBinDialogTitleStyle = style({

--- a/frontend/techpick/src/hooks/index.ts
+++ b/frontend/techpick/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { useClearSelectedPickIdsOnMount } from './useClearSelectedPickIdsOnMount
 export { useFetchTagList } from './useFetchTagList';
 export { useGetDragOverStyle } from './useGetDragOverStyle';
 export { useFetchPickRecordByFolderId } from './useFetchPickRecordByFolderId';
+export { useDisclosure } from './useDisclosure';

--- a/frontend/techpick/src/hooks/useDisclosure.ts
+++ b/frontend/techpick/src/hooks/useDisclosure.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState } from 'react';
+
+export function useDisclosure() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onOpen = () => {
+    setIsOpen(true);
+  };
+
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  const onToggle = () => {
+    setIsOpen((isOpen) => !isOpen);
+  };
+
+  return { isOpen, onOpen, onClose, onToggle };
+}


### PR DESCRIPTION
- Close #623 

## What is this PR? 🔍

- 기능 :
dialog의 open 상태를 관리하는 useDisclosure hook  구현
기존의 context menu 및 dialog가 drag안되게 수정

- issue : #623 

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
