### PR TITLE
[FEAT] 링크 클릭 시에 이벤트 수집 추가

### DIFF
--- a/frontend/schema/schema.d.ts
+++ b/frontend/schema/schema.d.ts
@@ -199,6 +199,26 @@ export interface paths {
         patch: operations["updatePick"];
         trace?: never;
     };
+    "/api/links/clicked": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 링크 클릭 이벤트 수집
+         * @description 서버에게 사용자가 링크를 클릭했음을 알립니다
+         */
+        post: operations["traceLinkAccess"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/folders": {
         parameters: {
             query?: never;
@@ -584,6 +604,12 @@ export interface components {
             /** Format: date-time */
             updatedAt?: string;
         };
+        "techpick.api.application.link.dto.LinkApiResponse": {
+            url?: string;
+            title?: string;
+            description?: string;
+            imageUrl?: string;
+        };
         "techpick.api.application.folder.dto.FolderApiRequest$Create": {
             /** @example backend */
             name: string;
@@ -834,11 +860,6 @@ export interface components {
             /** Format: int32 */
             size?: number;
             hasNext?: boolean;
-        };
-        "techpick.api.application.link.dto.LinkApiResponse": {
-            title?: string;
-            description?: string;
-            imageUrl?: string;
         };
         "techpick.api.application.tag.dto.TagApiRequest$Delete": {
             /**
@@ -1166,6 +1187,29 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["techpick.api.application.pick.dto.PickApiResponse$Pick"];
+                };
+            };
+        };
+    };
+    traceLinkAccess: {
+        parameters: {
+            query: {
+                /** @description 조회되는 url */
+                url: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["techpick.api.application.link.dto.LinkApiResponse"];
                 };
             };
         };

--- a/frontend/techpick/src/apis/apiConstants.ts
+++ b/frontend/techpick/src/apis/apiConstants.ts
@@ -7,6 +7,7 @@ const API_ENDPOINTS = {
   LINKS: 'links',
   SHARED: 'shared',
   LOGOUT: 'logout',
+  CLICKED: 'clicked',
 };
 
 export const API_URLS = {
@@ -39,4 +40,6 @@ export const API_URLS = {
   GET_LINK_OG_DATA: (url: string) => `${API_ENDPOINTS.LINKS}?url=${url}`,
   SHARE_FOLDER: API_ENDPOINTS.SHARED,
   POST_LOGOUT: `${API_ENDPOINTS.LOGOUT}`,
+  POST_CLICKED_LINK_URL: (url: string) =>
+    `${API_ENDPOINTS.LINKS}/${API_ENDPOINTS.CLICKED}?url=${url}`,
 };

--- a/frontend/techpick/src/apis/eventLog/index.ts
+++ b/frontend/techpick/src/apis/eventLog/index.ts
@@ -1,0 +1,1 @@
+export { postClickedLinkUrl } from './postClickedLinkUrl';

--- a/frontend/techpick/src/apis/eventLog/postClickedLinkUrl.ts
+++ b/frontend/techpick/src/apis/eventLog/postClickedLinkUrl.ts
@@ -1,0 +1,22 @@
+import { HTTPError } from 'ky';
+import { apiClient } from '../apiClient';
+import { API_URLS } from '../apiConstants';
+import { returnErrorFromHTTPError } from '../error';
+import type { PostClickedLinkUrlResponseType } from '@/types';
+
+export const postClickedLinkUrl = async (url: string) => {
+  try {
+    const response = await apiClient.post<PostClickedLinkUrlResponseType>(
+      API_URLS.POST_CLICKED_LINK_URL(encodeURIComponent(url))
+    );
+    const data = await response.json();
+
+    return data;
+  } catch (httpError) {
+    if (httpError instanceof HTTPError) {
+      const error = await returnErrorFromHTTPError(httpError);
+      throw error;
+    }
+    throw httpError;
+  }
+};

--- a/frontend/techpick/src/components/PickRecord/PickRecord.tsx
+++ b/frontend/techpick/src/components/PickRecord/PickRecord.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
+import { postClickedLinkUrl } from '@/apis/eventLog';
 import { useOpenUrlInNewTab } from '@/hooks';
 import { usePickStore, useTagStore, useUpdatePickStore } from '@/stores';
 import { formatDateString } from '@/utils';
@@ -47,6 +48,15 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
     }
   });
 
+  const onClickLink = async () => {
+    try {
+      openUrlInNewTab();
+      await postClickedLinkUrl(link.url);
+    } catch {
+      /*empty */
+    }
+  };
+
   return (
     <div
       className={pickRecordLayoutStyle}
@@ -63,7 +73,7 @@ export function PickRecord({ pickInfo }: PickViewItemComponentProps) {
         </div>
       </PickImageColumnLayout>
       {isHovered && !isDragging && (
-        <div className={linkLayoutStyle} onClick={openUrlInNewTab}>
+        <div className={linkLayoutStyle} onClick={onClickLink}>
           <ExternalLinkIcon className={externalLinkIconStyle} strokeWidth={2} />
         </div>
       )}

--- a/frontend/techpick/src/hooks/useOpenUrlInNewTab.ts
+++ b/frontend/techpick/src/hooks/useOpenUrlInNewTab.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 
 export function useOpenUrlInNewTab(url: string) {

--- a/frontend/techpick/src/types/PostClickedLinkUrlResponseType.ts
+++ b/frontend/techpick/src/types/PostClickedLinkUrlResponseType.ts
@@ -1,0 +1,6 @@
+import type { Concrete } from './util.type';
+import type { components } from '@/schema';
+
+export type PostClickedLinkUrlResponseType = Concrete<
+  components['schemas']['techpick.api.application.link.dto.LinkApiResponse']
+>;

--- a/frontend/techpick/src/types/index.ts
+++ b/frontend/techpick/src/types/index.ts
@@ -13,3 +13,4 @@ export type { PickViewItemComponentProps } from './PickViewItemComponentProps';
 export type { PickViewDraggableItemComponentProps } from './PickViewDraggableItemComponentProps';
 export type { PickViewDraggableItemListLayoutComponentProps } from './PickViewDraggableItemListLayoutComponentProps';
 export type { PickDeleteRequestType } from './PickDeleteRequestType';
+export type { PostClickedLinkUrlResponseType } from './PostClickedLinkUrlResponseType';


### PR DESCRIPTION
- Close #652 

## What is this PR? 🔍

- 기능 :
-  링크를 클릭할 때마다 이벤트를 수집하는 api를 호출합니다. 실패시에는 아무런 에러를 띄우지 않습니다.
- issue : #652 

## Changes 📝

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution
- error의 경우 apiClient에서 핸들링할 예정입니다. 또한 get요청이 실패할 경우 error boundary를 추가해서 에러를 다룰 예정입니다. 이는 #651 작업에서 하겠습니다.

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
