### PR TITLE
[REFACTOR] 폴더 제목 최대 길이 제한

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/folder/dto/FolderApiRequest.java
@@ -5,18 +5,19 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public class FolderApiRequest {
 
 	public record Create(
-		@Schema(example = "backend") @NotBlank(message = "{folder.name.notBlank}") String name,
+		@Schema(example = "backend") @NotBlank(message = "{folder.name.notBlank}") @Size(max = 100, message = "{folder.name.maxSize}") String name,
 		@Schema(example = "3") @NotNull(message = "{parentFolderId.notNull}") Long parentFolderId
 	) {
 	}
 
 	public record Update(
 		@Schema(example = "3") @NotNull(message = "{id.notNull}") Long id,
-		@Schema(example = "SpringBoot") @NotBlank(message = "{folder.name.notBlank}") String name
+		@Schema(example = "SpringBoot") @NotBlank(message = "{folder.name.notBlank}") @Size(max = 100, message = "{folder.name.maxSize}") String name
 	) {
 	}
 

--- a/backend/techpick-api/src/main/resources/messages.properties
+++ b/backend/techpick-api/src/main/resources/messages.properties
@@ -5,6 +5,7 @@ parentFolderId.notNull=부모 폴더 id는 null일 수 없습니다.
 destinationFolderId.notNull=이동할 폴더 id는 null일 수 없습니다.
 # folder
 folder.name.notBlank=Folder 이름은 비어있을 수 없습니다.
+folder.name.maxSize=Folder 제목 최대 길이인 100자를 초과하였습니다.
 # tag
 tag.name.notBlank=Tag 이름은 비어있을 수 없습니다.
 tag.colorNumber.notNull=Tag 색상은 null일 수 없습니다.


### PR DESCRIPTION
- Close #592

## What is this PR? 🔍

- 기능 :  폴더 제목 최대 길이 100자로 제한
- issue : #592

## Changes 📝
- 폴더 제목 최대 길이 제한 : 100자
