### PR TITLE
[FIX] 에러 메세지 JSON 올바르게 나오지 않던 것 변경 및 docker build 실패 원인 수정

### DIFF
--- a/frontend/techpick/next.config.js
+++ b/frontend/techpick/next.config.js
@@ -20,7 +20,7 @@ module.exports = withSentryConfig(module.exports, {
   // https://github.com/getsentry/sentry-webpack-plugin#options
 
   org: 'dmdgpdi',
-  project: 'javascript-nextjs',
+  project: 'techpick-frontend',
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,

--- a/frontend/techpick/src/apis/error.ts
+++ b/frontend/techpick/src/apis/error.ts
@@ -16,7 +16,7 @@ export const returnErrorFromHTTPError = async (
   const errorData = await error.response.json<ApiErrorBody>();
 
   if (errorData) {
-    return new Error(`${errorData.message}`);
+    return new Error(`${errorData.code} ${errorData.message}`);
   }
 
   return new Error(`알 수 없는 에러: ${error.response.statusText}`);


### PR DESCRIPTION
- Close #670 

## What is this PR? 🔍

- 기능 :
- issue : #670 

## Changes 📝
- 에러 메세지를 명세했던 json이 나오지 않는 문제를 @obvoso 님께서 찾아주셨습니다. 이에 코드를 확인해보니 extension 과는 달리 에러 코드를 따로 반환하지 않았고 이에 따라서  error code를 사용할 수 있도록 반환하게 하였습니다.
- docker file를 이용해 이미지를 만드는 것을 실패했었는데 이유는 sentry의 project name과  next.config.js의 project name이 다른 것이 원인이었습니다. 다시 설치해서 변경점을 확인하고 빌드해보니 성공했습니다.

<!--
## ScreenShot 📷
이번 PR에서의 변경점

| Before                     | After                     |
| -------------------------- | ------------------------- |
| ![Before Image](링크_넣기) | ![After Image](링크_넣기) |
-->

## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
