### PR TITLE
[FIX] 랭킹 정보에 링크 OG 태그 정보 추가 

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/ranking/controller/RankingApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/ranking/controller/RankingApiController.java
@@ -20,7 +20,7 @@ import techpick.api.application.ranking.dto.LinkInfoWithViewCount;
 import techpick.api.application.ranking.dto.RankingApiMapper;
 import techpick.api.domain.link.exception.ApiLinkException;
 import techpick.api.domain.link.service.LinkService;
-import techpick.api.infrastructure.ranking.RankingRepository;
+import techpick.api.infrastructure.ranking.RankingApi;
 import techpick.api.application.ranking.dto.RankingByViewCount;
 import techpick.core.dto.UrlWithCount;
 
@@ -34,7 +34,7 @@ import techpick.core.dto.UrlWithCount;
 @Tag(name = "추천/소개 API", description = "링크, 픽 등에 대한 소개")
 public class RankingApiController {
 
-	private final RankingRepository rankingRepository;
+	private final RankingApi rankingApi;
 	private final RankingApiMapper rankingApiMapper;
 	private final LinkService linkService;
 
@@ -64,14 +64,14 @@ public class RankingApiController {
 		var before30Days = currentDay.minusDays(30);
 
 		var dailyViewRanking = // 오늘 + 어제
-			mapToLinkInfoRanking(rankingRepository.getUrlRankingByViewCount(before1Day, currentDay, LIMIT).getBody());
+			mapToLinkInfoRanking(rankingApi.getUrlRankingByViewCount(before1Day, currentDay, LIMIT).getBody());
 
 		var past7DaysViewRanking = // 일주일 전 ~ 어제
-			mapToLinkInfoRanking(rankingRepository.getUrlRankingByViewCount(before7Days, before1Day, LIMIT).getBody());
+			mapToLinkInfoRanking(rankingApi.getUrlRankingByViewCount(before7Days, before1Day, LIMIT).getBody());
 
 		var past30DaysPickRanking = // 한달 전 ~ 어제
 			mapToLinkInfoRanking(
-				rankingRepository.getUrlRankingByPickedCount(before30Days, before1Day, LIMIT).getBody());
+				rankingApi.getUrlRankingByPickedCount(before30Days, before1Day, LIMIT).getBody());
 
 		var response = new RankingByViewCount(dailyViewRanking, past7DaysViewRanking, past30DaysPickRanking);
 		return ResponseEntity.ok(response);

--- a/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/LinkInfoWithViewCount.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/LinkInfoWithViewCount.java
@@ -1,0 +1,16 @@
+package techpick.api.application.ranking.dto;
+
+import jakarta.validation.constraints.NotNull;
+import techpick.core.dto.UrlWithCount;
+
+/**
+ * 랭킹 서버로 부터 얻은 URL 정보 {@link UrlWithCount} 에 Opengraph Tag를 추가한 DTO
+ */
+public record LinkInfoWithViewCount(
+	@NotNull String url,
+	String title,
+	String description,
+	String imageUrl,
+	Long count
+) {
+}

--- a/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/RankingApiMapper.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/RankingApiMapper.java
@@ -1,0 +1,20 @@
+package techpick.api.application.ranking.dto;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import techpick.api.domain.link.dto.LinkInfo;
+import techpick.core.dto.UrlWithCount;
+
+@Mapper(
+	componentModel = "spring",
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+	unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface RankingApiMapper {
+
+	@Mapping(target = "url", source = "urlWithCount.url")
+	LinkInfoWithViewCount toRankingWithLinkInfo(UrlWithCount urlWithCount, LinkInfo linkInfo);
+}

--- a/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/RankingByViewCount.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/ranking/dto/RankingByViewCount.java
@@ -3,16 +3,15 @@ package techpick.api.application.ranking.dto;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import techpick.core.dto.UrlWithCount;
 
 public record RankingByViewCount(
 	@Schema(description = "오늘 하루 동안 인기 있는 링크 Top 10")
-	List<UrlWithCount> dailyViewRanking,
+	List<LinkInfoWithViewCount> dailyViewRanking,
 
 	@Schema(description = "지난 7일동안 링크 조회 수 Top 10")
-	List<UrlWithCount> weeklyViewRanking,
+	List<LinkInfoWithViewCount> weeklyViewRanking,
 
 	@Schema(description = "지난 30일동안 링크가 픽된 횟수 Top 10")
-	List<UrlWithCount> monthlyPickRanking
+	List<LinkInfoWithViewCount> monthlyPickRanking
 ) {
 }

--- a/backend/techpick-api/src/main/java/techpick/api/config/HttpApiConfiguration.java
+++ b/backend/techpick-api/src/main/java/techpick/api/config/HttpApiConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
-import techpick.api.infrastructure.ranking.RankingRepository;
+import techpick.api.infrastructure.ranking.RankingApi;
 
 /**
  * 외부 서버와 통신하는 것을 Http Interface 방식으로 사용하기 위한 설정. <br>
@@ -20,10 +20,10 @@ public class HttpApiConfiguration {
 	private String rankingServerUrl;
 
 	@Bean
-	public RankingRepository rankingApi() {
+	public RankingApi rankingApi() {
 		var restClient = RestClient.create(rankingServerUrl);
 		var adapter = RestClientAdapter.create(restClient);
 		var proxy = HttpServiceProxyFactory.builderFor(adapter).build();
-		return proxy.createClient(RankingRepository.class);
+		return proxy.createClient(RankingApi.class);
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/user/service/RankingBasedStrategy.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/user/service/RankingBasedStrategy.java
@@ -14,7 +14,7 @@ import techpick.api.domain.link.exception.ApiLinkException;
 import techpick.api.domain.link.service.LinkService;
 import techpick.api.domain.pick.dto.PickCommand;
 import techpick.api.domain.pick.service.PickService;
-import techpick.api.infrastructure.ranking.RankingRepository;
+import techpick.api.infrastructure.ranking.RankingApi;
 import techpick.core.dto.UrlWithCount;
 import techpick.core.model.folder.Folder;
 import techpick.core.model.folder.FolderRepository;
@@ -32,7 +32,7 @@ public class RankingBasedStrategy implements InitialFolderStrategy {
 	private static final Integer LOAD_LIMIT = 15;
 
 	private final FolderRepository folderRepository;
-	private final RankingRepository rankingRepository;
+	private final RankingApi rankingApi;
 	private final PickService pickService;
 	private final LinkService linkService;
 
@@ -42,7 +42,7 @@ public class RankingBasedStrategy implements InitialFolderStrategy {
 		var currentDay = LocalDate.now();
 		var before1Day = currentDay.minusDays(1);
 		var before30Days = currentDay.minusDays(30);
-		var monthlyRanking = rankingRepository
+		var monthlyRanking = rankingApi
 			.getUrlRankingByViewCount(before30Days, before1Day, LOAD_LIMIT)
 			.getBody();
 		savePickFromRankingList(user.getId(), monthlyRanking, monthlyFolder.getId());

--- a/backend/techpick-api/src/main/java/techpick/api/domain/user/service/RankingBasedStrategy.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/user/service/RankingBasedStrategy.java
@@ -7,11 +7,9 @@ import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import techpick.api.domain.link.dto.LinkMapper;
 import techpick.api.domain.link.exception.ApiLinkException;
 import techpick.api.domain.link.service.LinkService;
 import techpick.api.domain.pick.dto.PickCommand;
@@ -45,7 +43,7 @@ public class RankingBasedStrategy implements InitialFolderStrategy {
 		var before1Day = currentDay.minusDays(1);
 		var before30Days = currentDay.minusDays(30);
 		var monthlyRanking = rankingRepository
-			.getLinkRankingByViewCount(before30Days, before1Day, LOAD_LIMIT)
+			.getUrlRankingByViewCount(before30Days, before1Day, LOAD_LIMIT)
 			.getBody();
 		savePickFromRankingList(user.getId(), monthlyRanking, monthlyFolder.getId());
 	}

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/ranking/RankingApi.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/ranking/RankingApi.java
@@ -15,7 +15,7 @@ import techpick.core.dto.UrlWithCount;
  * 랭킹 서버와 통신하기 위한 Http Interface. <br>
  * 형식은 techpick-api 모듈의 컨트롤러와 일치합니다.
  */
-public interface RankingRepository {
+public interface RankingApi {
 
 	/**
 	 * 조회수 기반 링크 랭킹

--- a/backend/techpick-api/src/main/java/techpick/api/infrastructure/ranking/RankingRepository.java
+++ b/backend/techpick-api/src/main/java/techpick/api/infrastructure/ranking/RankingRepository.java
@@ -21,7 +21,7 @@ public interface RankingRepository {
 	 * 조회수 기반 링크 랭킹
 	 */
 	@GetExchange("/ranking/link/view")
-	ResponseEntity<List<UrlWithCount>> getLinkRankingByViewCount(
+	ResponseEntity<List<UrlWithCount>> getUrlRankingByViewCount(
 		@RequestParam("date_begin") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate dateBegin,
 		@RequestParam("date_end") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate dateEnd,
 		@RequestParam(required = false, defaultValue = "5") Integer limit
@@ -31,7 +31,7 @@ public interface RankingRepository {
 	 * 픽된 횟수 기반 링크 랭킹
 	 */
 	@GetExchange("/ranking/link/picked")
-	ResponseEntity<List<UrlWithCount>> getLinkRankingByPickedCount(
+	ResponseEntity<List<UrlWithCount>> getUrlRankingByPickedCount(
 		@RequestParam("date_begin") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate dateBegin,
 		@RequestParam("date_end") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate dateEnd,
 		@RequestParam(required = false, defaultValue = "5") Integer limit


### PR DESCRIPTION
- Close #697

## What is this PR? 🔍

url과 count만 반환하던 랭킹 정보에, 링크 OG 태그 정보도 함께 반환합니다.

- 기능 : 기존 랭킹 조회 결과에 Link OG 태그 정보도 포함
- issue : #697 
