### PR TITLE
[FEAT] 추천 링크로 부터 픽 생성 API 구현

### DIFF
--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/controller/PickApiController.java
@@ -210,7 +210,7 @@ public class PickApiController {
 		@ApiResponse(responseCode = "200", description = "픽 생성 성공"),
 		@ApiResponse(responseCode = "403", description = "접근할 수 없는 폴더")
 	})
-	public ResponseEntity<?> savePickFromRecommend(@LoginUserId Long userId,
+	public ResponseEntity<PickApiResponse.CreateFromRecommend> savePickFromRecommend(@LoginUserId Long userId,
 		@Valid @RequestBody PickApiRequest.Create request) {
 		boolean existPick;
 		PickResult.Pick pickResult;

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
-import techpick.api.domain.folder.dto.FolderResult;
 import techpick.api.domain.link.dto.LinkInfo;
 import techpick.api.domain.pick.dto.PickResult;
 
@@ -56,8 +55,7 @@ public class PickApiResponse {
 
 	public record CreateFromRecommend(
 		boolean exist,
-		PickResult.Pick pick,
-		FolderResult parentFolder
+		PickResult.Pick pick
 	) {
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
+++ b/backend/techpick-api/src/main/java/techpick/api/application/pick/dto/PickApiResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.NonNull;
+import techpick.api.domain.folder.dto.FolderResult;
 import techpick.api.domain.link.dto.LinkInfo;
 import techpick.api.domain.pick.dto.PickResult;
 
@@ -51,6 +51,13 @@ public class PickApiResponse {
 	public record PickExists(
 		@NotNull Boolean exist,
 		PickApiResponse.Pick pick
+	) {
+	}
+
+	public record CreateFromRecommend(
+		boolean exist,
+		PickResult.Pick pick,
+		FolderResult parentFolder
 	) {
 	}
 }

--- a/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
+++ b/backend/techpick-api/src/main/java/techpick/api/domain/folder/service/FolderService.java
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import techpick.api.annotation.LoginUserIdDistributedLock;
 import techpick.api.domain.folder.dto.FolderCommand;
 import techpick.api.domain.folder.dto.FolderMapper;
 import techpick.api.domain.folder.dto.FolderResult;
 import techpick.api.domain.folder.exception.ApiFolderException;
 import techpick.api.infrastructure.folder.FolderDataHandler;
-import techpick.api.annotation.LoginUserIdDistributedLock;
 import techpick.api.infrastructure.pick.PickDataHandler;
 import techpick.api.infrastructure.sharedFolder.SharedFolderDataHandler;
 import techpick.core.model.folder.Folder;
@@ -60,6 +60,13 @@ public class FolderService {
 		return basicFolders.stream()
 			.map(folderMapper::toResult)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public FolderResult getFolder(Long userId, Long folderId) {
+		Folder folder = folderDataHandler.getFolder(folderId);
+		validateFolderAccess(userId, folder);
+		return folderMapper.toResult(folder);
 	}
 
 	/**


### PR DESCRIPTION
- Close #734

## What is this PR? 🔍

- 기능 : 추천 링크로 부터 픽 생성 API 구현
- issue : #734

## Changes 📝

![스크린샷 2024-12-11 오후 12 31 31](https://github.com/user-attachments/assets/f0c82fc8-e679-43e9-b170-1690e9da324e)
추천 페이지에서 dnd로 픽 생성시 이미 존재하는 픽일 경우 단순 오류메세지만 발생


### `POST` : `/api/picks/recommend`
중복된 픽일 경우 해당 폴더로 이동하는 메세지가 나오는 것이 사용자 경험에 더 좋을것으로 판단되어 전용 api 구현
ex) 이미 등록된 픽입니다. 해당 폴더로 이동하겠습니까? yes / no


### 응답 예시

![스크린샷 2024-12-11 오후 1 38 04](https://github.com/user-attachments/assets/8d121532-14f2-47df-b016-3648ea98d31a)

- `exist` : 이미 존재하는 픽인지 여부 (`true`/`false`)
- `pick` : 새로 생성되거나 기존에 있는 픽 정보
- `parentFolder` : 픽의 부모 폴더 정보
